### PR TITLE
Issue/fix 43 wrong type

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -439,12 +439,12 @@ Error functions implement the Error interface on the zuora.Error struct.
 
 ```go
 type ErrorResponse struct {
-	Status string      `json:"status,omitempty"`
-	Title  string      `json:"title,omitempty"`
-	Detail string      `json:"detail,omitempty"`
-	Field  string      `json:"field,omitempty"`
-	Extra  interface{} `json:"extra,omitempty"`
-	Links  struct {
+	StatusCode int         `json:"status,omitempty"`
+	Title      string      `json:"title,omitempty"`
+	Detail     string      `json:"detail,omitempty"`
+	Field      string      `json:"field,omitempty"`
+	Extra      interface{} `json:"extra,omitempty"`
+	Links      struct {
 		Documentation URL `json:"documentation,omitempty"`
 	} `json:"_links,omitempty"`
 }

--- a/mollie/common_types.go
+++ b/mollie/common_types.go
@@ -145,12 +145,12 @@ const (
 
 // ErrorResponse describes the cancel endpoint response if there is an error
 type ErrorResponse struct {
-	Status string      `json:"status,omitempty"`
-	Title  string      `json:"title,omitempty"`
-	Detail string      `json:"detail,omitempty"`
-	Field  string      `json:"field,omitempty"`
-	Extra  interface{} `json:"extra,omitempty"`
-	Links  struct {
+	StatusCode int         `json:"status,omitempty"`
+	Title      string      `json:"title,omitempty"`
+	Detail     string      `json:"detail,omitempty"`
+	Field      string      `json:"field,omitempty"`
+	Extra      interface{} `json:"extra,omitempty"`
+	Links      struct {
 		Documentation URL `json:"documentation,omitempty"`
 	} `json:"_links,omitempty"`
 }

--- a/mollie/orders_test.go
+++ b/mollie/orders_test.go
@@ -343,7 +343,7 @@ func TestOrdersService_CreatePaymentFailed(t *testing.T) {
 	}
 
 	_, errResp, err := tClient.Orders.CreateOrderPayment(orderID, &ordPay)
-	if err == nil {
+	if errResp == nil || err != nil {
 		t.Fail()
 	}
 
@@ -409,7 +409,7 @@ func TestOrdersService_CreateOrderRefundFailed(t *testing.T) {
 	}
 
 	_, errResp, err := tClient.Orders.CreateOrderRefund(orderID, &order)
-	if err == nil {
+	if errResp == nil || err != nil {
 		t.Fail()
 	}
 

--- a/mollie/orders_test.go
+++ b/mollie/orders_test.go
@@ -217,6 +217,7 @@ func TestOrdersService_CancelOrderLines(t *testing.T) {
 	defer teardown()
 
 	orderID := "ord_8wmqcHMN4U"
+	isError := false
 
 	_ = tClient.WithAuthenticationValue("test_token")
 	tMux.HandleFunc("/v2/orders/"+orderID+"/lines", func(w http.ResponseWriter, r *http.Request) {
@@ -240,6 +241,8 @@ func TestOrdersService_CancelOrderLines(t *testing.T) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write([]byte(testdata.CancelOrderLinesResponseCancelReject))
 
+				isError = true
+
 				break
 			}
 
@@ -247,11 +250,16 @@ func TestOrdersService_CancelOrderLines(t *testing.T) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 				_, _ = w.Write([]byte(testdata.CancelOrderLinesResponseAmountRequired))
 
+				isError = true
+
 				break
 			}
 		}
 
-		w.WriteHeader(http.StatusNoContent)
+		if !isError {
+			w.WriteHeader(http.StatusNoContent)
+		}
+
 	})
 
 	var ordLines Orders
@@ -260,7 +268,7 @@ func TestOrdersService_CancelOrderLines(t *testing.T) {
 	}
 
 	res, err := tClient.Orders.CancelOrderLine(orderID, &ordLines)
-	if err == nil {
+	if res == nil || err != nil {
 		t.Fail()
 	}
 	t.Log(res)
@@ -270,7 +278,7 @@ func TestOrdersService_CancelOrderLines(t *testing.T) {
 	}
 
 	res, err = tClient.Orders.CancelOrderLine(orderID, &ordLines)
-	if err == nil {
+	if res == nil || err != nil {
 		t.Fail()
 	}
 	t.Log(res)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix wrong type of Status (string) in ErrorResponse struct. Replace it with StatusCode (int). Included are other fixes that I found while I'm testing the orders_test.go as a side effect of my previous PR #41. This is why I'm not squashing my commits. Now, for the tests of TestOrdersService_CancelOrderLines, TestOrdersService_CreatePaymentFailed, and TestOrdersService_CreateOrderRefundFailed, for those to be failed the ErrorResponse should nil and the error should not nil.

## Motivation and context

Fixes #43 

## How has this been tested?
Tested using the built-in Golang test tools.
Golang version go1.12.6 windows/amd64.
Following the steps to reproduce, produces the expected results.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/26384044/68463502-5f1bab00-0241-11ea-97ef-91ed5e63d3ab.png)


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
