### PR TITLE
Response closed error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## master
 
+### Fixed
+- Fixed error reported when trying to access the `mollie.Error.Response.Body` content (#47).
+
+## v1.0.0
+
 ### Added
 - Base HTTP Client for interacting with Mollie REST API
 - Tests for the added code

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -214,10 +214,12 @@ type Response struct {
 
 func newResponse(r *http.Response) *Response {
 	var res Response
-	if c, err := ioutil.ReadAll(r.Body); err == nil {
+	c, err := ioutil.ReadAll(r.Body)
+	if err == nil {
 		res.content = c
 	}
 	json.NewDecoder(r.Body).Decode(&res)
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(c))
 	res.Response = r
 	return &res
 }

--- a/mollie/payments_test.go
+++ b/mollie/payments_test.go
@@ -270,6 +270,18 @@ func TestPaymentsService_EncodingResponseErrors(t *testing.T) {
 	}
 }
 
+func TestPaymentFailedResponseAvailable(t *testing.T) {
+	setup()
+	defer teardown()
+	tMux.HandleFunc("/v2/payments/", unprocessableEntityHandler)
+
+	_, err := tClient.Payments.Create(Payment{})
+
+	if err == nil {
+		t.Error("expected error and got nil")
+	}
+}
+
 func errorHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
@@ -277,4 +289,9 @@ func errorHandler(w http.ResponseWriter, r *http.Request) {
 func encodingHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(`{hello: [{},]}`))
+}
+
+func unprocessableEntityHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	_, _ = w.Write([]byte(testdata.CreateOrderPaymentResponseFailed))
 }


### PR DESCRIPTION
## Description

When a response body has been read, it is no longer accessible for reading and when an error occurs this blocks the user to obtain relevant information about the error.

This PR adds a refreshed ReadCloser to the Response once the content has been processed.

## Motivation and context

Fixes #47 

## How has this been tested?

Test case added covering the reported error.

## Screenshots (if appropriate)

*Full object preview*
![Screenshot 2019-12-12 at 22 01 48](https://user-images.githubusercontent.com/7926849/70749234-17021380-1d2c-11ea-8654-281cebb1796a.png)

*Reader enabled*
![Screenshot 2019-12-12 at 22 02 01](https://user-images.githubusercontent.com/7926849/70749277-3862ff80-1d2c-11ea-963c-0a668ec623ee.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
