### PR TITLE
Fixed amount query parsing for payment methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## master
 
+## v1.6.3
+
+### Fixed
+- Error when parsing amount values on payment methods #94
+
 ## v1.6.2
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -1152,7 +1152,8 @@ type MethodsOptions struct {
 	Include   string `url:"include,omitempty"`
 	// Use for List method only
 	SequenceType   SequenceType `url:"sequenceType,omitempty"`
-	Amount         Amount       `url:"amount,omitempty"`
+	AmountCurrency string       `url:"amount[currency],omitempty"`
+	AmountValue    string       `url:"amount[value],omitempty"`
 	Resource       string       `url:"resource,omitempty"`
 	BillingCountry string       `url:"billingCountry,omitempty"`
 	IncludeWallets string       `url:"includeWallets,omitempty"`

--- a/mollie/methods.go
+++ b/mollie/methods.go
@@ -59,7 +59,8 @@ type MethodsOptions struct {
 	Include   string `url:"include,omitempty"`
 	// Use for List method only
 	SequenceType   SequenceType `url:"sequenceType,omitempty"`
-	Amount         Amount       `url:"amount,omitempty"`
+	AmountCurrency string       `url:"amount[currency],omitempty"`
+	AmountValue    string       `url:"amount[value],omitempty"`
 	Resource       string       `url:"resource,omitempty"`
 	BillingCountry string       `url:"billingCountry,omitempty"`
 	IncludeWallets string       `url:"includeWallets,omitempty"`

--- a/mollie/methods_test.go
+++ b/mollie/methods_test.go
@@ -9,6 +9,81 @@ import (
 	"github.com/VictorAvelar/mollie-api-go/testdata"
 )
 
+func TestMethodsService_ListWithQueryOptionsAmountCurrency(t *testing.T) {
+	setup()
+	defer teardown()
+	_ = tClient.WithAuthenticationValue("test_token")
+
+	tMux.HandleFunc("/v2/methods", func(w http.ResponseWriter, r *http.Request) {
+		testHeader(t, r, AuthHeader, "Bearer test_token")
+		testMethod(t, r, "GET")
+		if _, ok := r.Header[AuthHeader]; !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+
+		if r.URL.RawQuery != "amount%5Bcurrency%5D=USD&amount%5Bvalue%5D=100.00" {
+			t.Fatal(r.URL.RawQuery)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(testdata.ListMethodsResponse))
+	})
+
+	opts := &MethodsOptions{
+		AmountCurrency: "USD",
+		AmountValue:    "100.00",
+	}
+
+	res, err := tClient.Methods.List(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Count <= 0 {
+		t.Error("expecting methods and got 0")
+	}
+}
+
+func TestMethodsService_ListWithQueryOptionsAll(t *testing.T) {
+	setup()
+	defer teardown()
+	_ = tClient.WithAuthenticationValue("test_token")
+
+	tMux.HandleFunc("/v2/methods", func(w http.ResponseWriter, r *http.Request) {
+		testHeader(t, r, AuthHeader, "Bearer test_token")
+		testMethod(t, r, "GET")
+		if _, ok := r.Header[AuthHeader]; !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+
+		if r.URL.RawQuery != "amount%5Bcurrency%5D=USD&amount%5Bvalue%5D=100.00&billingCountry=DE&includeWallets=applepay&locale=de_DE&resource=orders&sequenceType=first" {
+			t.Fatal(r.URL.RawQuery)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(testdata.ListMethodsResponse))
+	})
+
+	opts := &MethodsOptions{
+		AmountCurrency: "USD",
+		AmountValue:    "100.00",
+		Resource: "orders",
+		SequenceType: FirstSequence,
+		Locale: German,
+		BillingCountry: "DE",
+		IncludeWallets: "applepay",
+	}
+
+	res, err := tClient.Methods.List(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Count <= 0 {
+		t.Error("expecting methods and got 0")
+	}
+}
+
 func TestMethodsService_Get(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When encoding payment methods query parameters, the amount was parsed as `amount.currency=xxx&amount.value=xxx`, the correct format must be `amount[currency]=xxx&amount[value]=xxx`.

## Motivation and context

Why is this change required? What problem does it solve?

Fix the way payment methods query parameters are parsed.

## How has this been tested?

Distributor ID: Ubuntu
Description:    Ubuntu 20.04.1 LTS
Release:         20.04
Codename:    focal

Unit tests added for pasing query values in payment methods requests.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
