### PR TITLE
Added parsed response content to error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## master
 
+## v1.6.4
+
+### Added
+- Full http error content when the response is within the http error range #95
+
 ## v1.6.3
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -621,6 +621,7 @@ Valid Embed query string value.
 type Error struct {
 	Code     int            `json:"code"`
 	Message  string         `json:"message"`
+	Content  string         `json:"content,omitempty"`
 	Response *http.Response `json:"response"` // the full response that produced the error
 }
 ```

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -189,12 +189,13 @@ Error reports details on a failed API request.
 type Error struct {
 	Code     int            `json:"code"`
 	Message  string         `json:"message"`
+	Content  string         `json:"content,omitempty"`
 	Response *http.Response `json:"response"` // the full response that produced the error
 }
 
 // Error function complies with the error interface
 func (e *Error) Error() string {
-	return fmt.Sprintf("response failed with status %v", e.Message)
+	return fmt.Sprintf("response failed with status %s\npayload: %v", e.Message, e.Content)
 }
 
 /*
@@ -205,6 +206,11 @@ func newError(r *http.Response) *Error {
 	e.Response = r
 	e.Code = r.StatusCode
 	e.Message = r.Status
+	c, err := ioutil.ReadAll(r.Body)
+	if err == nil {
+		e.Content = string(c)
+	}
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(c))
 	return &e
 }
 

--- a/mollie/mollie_test.go
+++ b/mollie/mollie_test.go
@@ -244,11 +244,19 @@ func TestCheckResponse(t *testing.T) {
 	res1 := &http.Response{
 		StatusCode: http.StatusNotFound,
 		Status:     http.StatusText(http.StatusNotFound),
+		Body:       ioutil.NopCloser(strings.NewReader("not found ok")),
+	}
+
+	res3 := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Status:     http.StatusText(http.StatusNotFound),
+		Body:       ioutil.NopCloser(strings.NewReader("")),
 	}
 
 	res2 := &http.Response{
 		StatusCode: http.StatusOK,
 		Status:     http.StatusText(http.StatusOK),
+		Body:       ioutil.NopCloser(strings.NewReader("success ok")),
 	}
 
 	tests := []struct {
@@ -265,6 +273,11 @@ func TestCheckResponse(t *testing.T) {
 			"not found response",
 			"Not Found",
 			res1,
+		},
+		{
+			"success with empty body",
+			"",
+			res3,
 		},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

At the moment, when you get a response with a status code > 399, then it will be returned as an error using `mollie.Error` struct.
When rendered as a string, the error was only displaying the status code message, after this PR the string representation of the error will also give you the payload as it might become relevant for debugging or testing integrations.

## Motivation and context

Why is this change required? What problem does it solve?

Provides the full http error content when the response is within the http error range.

## How has this been tested?

Please describe in detail how you tested your changes.

Unit tests for the `CheckResponse` method were added.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
