### PR TITLE
payment details address as object

### DIFF
--- a/mollie/payment_details.go
+++ b/mollie/payment_details.go
@@ -52,46 +52,62 @@ type UsedGiftCard struct {
 
 // PaymentDetails contains details for the specified payment method
 type PaymentDetails struct {
-	BankAccount        string             `json:"bankAccount,omitempty"`
-	BankBIC            string             `json:"bankBic,omitempty"`
-	BankName           string             `json:"bankName,omitempty"`
-	BankReason         string             `json:"bankReason,omitempty"`
-	BatchReference     string             `json:"batchReference,omitempty"`
-	BillingEmail       string             `json:"billingEmail,omitempty"`
-	CardAudience       string             `json:"cardAudience,omitempty"`
-	CardCountryCode    string             `json:"cardCountryCode,omitempty"`
-	CardFingerPrint    string             `json:"cardFingerPrint,omitempty"`
-	CardHolder         string             `json:"cardHolder,omitempty"`
-	CardLabel          string             `json:"cardLabel,omitempty"`
-	CardNumber         string             `json:"cardNumber,omitempty"`
-	CardSecurity       string             `json:"cardSecurity,omitempty"`
-	ConsumerAccount    string             `json:"consumerAccount,omitempty"`
-	ConsumerBIC        string             `json:"consumerBic,omitempty"`
-	ConsumerName       string             `json:"consumerName,omitempty"`
-	ConsumerReference  string             `json:"consumerReference,omitempty"`
-	CreditorIdentifier string             `json:"creditorIdentifier,omitempty"`
-	DueDate            *ShortDate         `json:"dueDate,omitempty"`
-	EndToEndIdentifier string             `json:"endToEndIdentifier,omitempty"`
-	FailureReason      FailureReason      `json:"failureReason,omitempty"`
-	FeeRegion          FeeRegion          `json:"feeRegion,omitempty"`
-	FileReference      string             `json:"fileReference,omitempty"`
-	GiftCards          []*UsedGiftCard    `json:"giftCards,omitempty"`
-	MandateReference   string             `json:"mandateReference,omitempty"`
-	PaypalDigitalGoods bool               `json:"digitalGoods,omitempty"`
-	PaypalFee          Amount             `json:"paypalFee,omitempty"`
-	PaypalPayerID      string             `json:"paypalPayerId,omitempty"`
-	PaypalReference    string             `json:"paypalReference,omitempty"`
-	QRCode             *QRCode            `json:"qrCode,omitempty"`
-	RemainderAmount    *Amount            `json:"remainderAmount,omitempty"`
-	RemainderMethod    PaymentMethod      `json:"remainderMethod,omitempty"`
-	SellerProtection   EligibilityReasons `json:"sellerProtection,omitempty"`
-	ShippingAddress    string             `json:"shippingAddress,omitempty"`
-	SignatureDate      *ShortDate         `json:"signatureDate,omitempty"`
-	TransferReference  string             `json:"transferReference,omitempty"`
-	VoucherNumber      string             `json:"voucherNumber,omitempty"`
-	Wallet             string             `json:"wallet,omitempty"`
+	BankAccount        string                 `json:"bankAccount,omitempty"`
+	BankBIC            string                 `json:"bankBic,omitempty"`
+	BankName           string                 `json:"bankName,omitempty"`
+	BankReason         string                 `json:"bankReason,omitempty"`
+	BatchReference     string                 `json:"batchReference,omitempty"`
+	BillingEmail       string                 `json:"billingEmail,omitempty"`
+	CardAudience       string                 `json:"cardAudience,omitempty"`
+	CardCountryCode    string                 `json:"cardCountryCode,omitempty"`
+	CardFingerPrint    string                 `json:"cardFingerPrint,omitempty"`
+	CardHolder         string                 `json:"cardHolder,omitempty"`
+	CardLabel          string                 `json:"cardLabel,omitempty"`
+	CardNumber         string                 `json:"cardNumber,omitempty"`
+	CardSecurity       string                 `json:"cardSecurity,omitempty"`
+	ConsumerAccount    string                 `json:"consumerAccount,omitempty"`
+	ConsumerBIC        string                 `json:"consumerBic,omitempty"`
+	ConsumerName       string                 `json:"consumerName,omitempty"`
+	ConsumerReference  string                 `json:"consumerReference,omitempty"`
+	CreditorIdentifier string                 `json:"creditorIdentifier,omitempty"`
+	DueDate            *ShortDate             `json:"dueDate,omitempty"`
+	EndToEndIdentifier string                 `json:"endToEndIdentifier,omitempty"`
+	FailureReason      FailureReason          `json:"failureReason,omitempty"`
+	FeeRegion          FeeRegion              `json:"feeRegion,omitempty"`
+	FileReference      string                 `json:"fileReference,omitempty"`
+	GiftCards          []*UsedGiftCard        `json:"giftCards,omitempty"`
+	MandateReference   string                 `json:"mandateReference,omitempty"`
+	PaypalDigitalGoods bool                   `json:"digitalGoods,omitempty"`
+	PaypalFee          Amount                 `json:"paypalFee,omitempty"`
+	PaypalPayerID      string                 `json:"paypalPayerId,omitempty"`
+	PaypalReference    string                 `json:"paypalReference,omitempty"`
+	QRCode             *QRCode                `json:"qrCode,omitempty"`
+	RemainderAmount    *Amount                `json:"remainderAmount,omitempty"`
+	RemainderMethod    PaymentMethod          `json:"remainderMethod,omitempty"`
+	SellerProtection   EligibilityReasons     `json:"sellerProtection,omitempty"`
+	ShippingAddress    *PaymentDetailsAddress `json:"shippingAddress,omitempty"`
+	SignatureDate      *ShortDate             `json:"signatureDate,omitempty"`
+	TransferReference  string                 `json:"transferReference,omitempty"`
+	VoucherNumber      string                 `json:"voucherNumber,omitempty"`
+	Wallet             string                 `json:"wallet,omitempty"`
 	Links              struct {
 		Status    *URL `json:"status,omitempty"`
 		PayOnline *URL `json:"payOnline,omitempty"`
 	} `json:"_links,omitempty"`
+}
+
+// PaymentDetailsAddress identify both the address and the person the payment is shipped to.
+type PaymentDetailsAddress struct {
+	OrganizationName string      `json:"organizationName,omitempty"`
+	Title            string      `json:"title,omitempty"`
+	GivenName        string      `json:"givenName,omitempty"`
+	FamilyName       string      `json:"familyName,omitempty"`
+	Email            string      `json:"email,omitempty"`
+	Phone            PhoneNumber `json:"phone,omitempty"`
+	StreetAndNumber  string      `json:"streetAndNumber,omitempty"`
+	StreetAdditional string      `json:"streetAdditional,omitempty"`
+	PostalCode       string      `json:"postalCode,omitempty"`
+	City             string      `json:"city,omitempty"`
+	Region           string      `json:"region,omitempty"`
+	Country          string      `json:"country,omitempty"`
 }


### PR DESCRIPTION
From the Mollie changelog February 2020 - Thursday, 20th

* Added shippingAddress to the PayPal payment details.

Fetching a PayPal payment started failing a few days ago because the Payment / Details / ShippingAddress is a string and not an object.

This PR adds the fields to the PaymentDetails struct.