### PR TITLE
Fix auth key parsing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## master
 
+## v2.2.1
+
+### Added
+- User agent header
+
+### Fixed
+- Parse auth key from any given env var
 ## v2.2.0
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -237,26 +237,27 @@ CategoryCode specifies an industry or category
 
 ```go
 const (
-	BookMagazinesAndNewspapers      CategoryCode = 5192
-	GeneralMerchandise              CategoryCode = 5399
-	FoodAndDrinks                   CategoryCode = 5499
-	AutomotiveProducts              CategoryCode = 5533
-	ChildrenProducts                CategoryCode = 5641
-	ClothingAndShoes                CategoryCode = 5651
-	ElectronicsComputersAndSoftware CategoryCode = 5732
-	HostingOrVpnServices            CategoryCode = 5734
-	Entertainment                   CategoryCode = 5735
-	CreditsOrVouchersOrGiftCards    CategoryCode = 5815
-	Alcohol                         CategoryCode = 5921
-	JewelryAndAccessories           CategoryCode = 5944
-	HealthAndBeautyProducts         CategoryCode = 5977
-	FinancialServices               CategoryCode = 6012
-	Consultancy                     CategoryCode = 7299
-	TravelRentalAndTransportation   CategoryCode = 7999
-	AdvisingOrCoachingOrTraining    CategoryCode = 8299
-	CharityAndDonations             CategoryCode = 8398
-	PoliticalParties                CategoryCode = 8699
-	Others                          CategoryCode = 0
+	BookMagazinesAndNewspapers          CategoryCode = 5192
+	GeneralMerchandise                  CategoryCode = 5399
+	FoodAndDrinks                       CategoryCode = 5499
+	AutomotiveProducts                  CategoryCode = 5533
+	ChildrenProducts                    CategoryCode = 5641
+	ClothingAndShoes                    CategoryCode = 5651
+	MarketplaceCrowdfundingAndDonations CategoryCode = 5262
+	ElectronicsComputersAndSoftware     CategoryCode = 5732
+	HostingOrVpnServices                CategoryCode = 5734
+	Entertainment                       CategoryCode = 5735
+	CreditsOrVouchersOrGiftCards        CategoryCode = 5815
+	Alcohol                             CategoryCode = 5921
+	JewelryAndAccessories               CategoryCode = 5944
+	HealthAndBeautyProducts             CategoryCode = 5977
+	FinancialServices                   CategoryCode = 6012
+	Consultancy                         CategoryCode = 7299
+	TravelRentalAndTransportation       CategoryCode = 7999
+	AdvisingOrCoachingOrTraining        CategoryCode = 8299
+	CharityAndDonations                 CategoryCode = 8398
+	PoliticalParties                    CategoryCode = 8699
+	Others                              CategoryCode = 0
 )
 ```
 Available category codes
@@ -902,7 +903,7 @@ endpoint.
 type ListInvoiceOptions struct {
 	Reference string `json:"reference,omitempty"`
 	Year      string `json:"year,omitempty"`
-	From      int64  `json:"from,omitempty"`
+	From      string `json:"from,omitempty"`
 	Limit     int64  `json:"limit,omitempty"`
 }
 ```
@@ -1862,6 +1863,7 @@ type PaymentMethodInfo struct {
 	MaximumAmount *Amount                 `json:"maximumAmount,omitempty"`
 	Image         *Image                  `json:"image,omitempty"`
 	Pricing       []*PaymentMethodPricing `json:"pricing,omitempty"`
+	Status        *PaymentMethodStatus    `json:"status,omitempty"`
 	Links         MethodsLinks            `json:"_links,omitempty"`
 }
 ```
@@ -1872,14 +1874,35 @@ PaymentMethodInfo describes a single method with details.
 
 ```go
 type PaymentMethodPricing struct {
-	Description string  `json:"description,omitempty"`
-	Fixed       *Amount `json:"fixed,omitempty"`
-	Variable    string  `json:"variable,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Fixed       *Amount   `json:"fixed,omitempty"`
+	Variable    string    `json:"variable,omitempty"`
+	FeeRegion   FeeRegion `json:"feeRegion,omitempty"`
 }
 ```
 
 PaymentMethodPricing contains information about commissions and fees applicable
 to a payment method.
+
+#### type PaymentMethodStatus
+
+```go
+type PaymentMethodStatus string
+```
+
+PaymentMethodStatus tels the status that the method is in. Possible values:
+activated pending-boarding pending-review pending-external rejected.
+
+```go
+const (
+	PaymentMethodActivated       PaymentMethodStatus = "activated"
+	PaymentMethodPendingBoarding PaymentMethodStatus = "pending-boarding"
+	PaymentMethodPendingReview   PaymentMethodStatus = "pending-review"
+	PaymentMethodPendingExternal PaymentMethodStatus = "pending-external"
+	PaymentMethodRejected        PaymentMethodStatus = "pending-rejected"
+)
+```
+Available payment method statuses
 
 #### type PaymentOptions
 

--- a/mollie/invoices.go
+++ b/mollie/invoices.go
@@ -56,7 +56,7 @@ type InvoiceLinks struct {
 type ListInvoiceOptions struct {
 	Reference string `json:"reference,omitempty"`
 	Year      string `json:"year,omitempty"`
-	From      int64  `json:"from,omitempty"`
+	From      string `json:"from,omitempty"`
 	Limit     int64  `json:"limit,omitempty"`
 }
 

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -32,6 +33,7 @@ var (
 type Client struct {
 	BaseURL        *url.URL
 	authentication string
+	userAgent      string
 	client         *http.Client
 	common         service // Reuse a single struct instead of allocating one for each service on the heap.
 	config         *Config
@@ -176,8 +178,11 @@ func NewClient(baseClient *http.Client, c *Config) (mollie *Client, err error) {
 	tkn, ok := os.LookupEnv(c.auth)
 	if ok {
 		mollie.authentication = tkn
-	} else {
-		return mollie, errEmptyAuthKey
+		mollie.userAgent = strings.Join([]string{
+			runtime.GOOS,
+			runtime.GOARCH,
+			runtime.Version(),
+		}, ";")
 	}
 	return
 }

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -111,6 +111,7 @@ func (c *Client) NewAPIRequest(method string, uri string, body interface{}) (req
 	req.Header.Add(AuthHeader, strings.Join([]string{TokenType, c.authentication}, " "))
 	req.Header.Set("Content-Type", RequestContentType)
 	req.Header.Set("Accept", RequestContentType)
+	req.Header.Set("User-Agent", c.userAgent)
 
 	return
 }

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -24,8 +24,8 @@ const (
 )
 
 var (
-	errEmptyAPIKey = errors.New("you must provide a non-empty API key")
-	errBadBaseURL  = errors.New("malformed base url, it must contain a trailing slash")
+	errEmptyAuthKey = errors.New("you must provide a non-empty authentication key")
+	errBadBaseURL   = errors.New("malformed base url, it must contain a trailing slash")
 )
 
 // Client manages communication with Mollie's API.
@@ -65,7 +65,7 @@ type service struct {
 // This should only be used when environment variables are "impossible" to be used.
 func (c *Client) WithAuthenticationValue(k string) error {
 	if k == "" {
-		return errEmptyAPIKey
+		return errEmptyAuthKey
 	}
 
 	c.authentication = strings.TrimSpace(k)
@@ -172,13 +172,12 @@ func NewClient(baseClient *http.Client, c *Config) (mollie *Client, err error) {
 	mollie.Miscellaneous = (*MiscellaneousService)(&mollie.common)
 	mollie.Mandates = (*MandatesService)(&mollie.common)
 
-	// Parse authorization from environment
-	tkn, ok := os.LookupEnv(APITokenEnv)
+	// Parse authorization from specified environment variable
+	tkn, ok := os.LookupEnv(c.auth)
 	if ok {
 		mollie.authentication = tkn
 	} else {
-		tkn = os.Getenv(c.auth)
-		mollie.authentication = tkn
+		return mollie, errEmptyAuthKey
 	}
 	return
 }

--- a/mollie/mollie_test.go
+++ b/mollie/mollie_test.go
@@ -147,7 +147,7 @@ func TestClient_WithAuthenticationValue_Error(t *testing.T) {
 	err := tClient.WithAuthenticationValue("")
 
 	if err == nil {
-		t.Errorf("unexpected error, want %v and got %v", errEmptyAPIKey, err)
+		t.Errorf("unexpected error, want %v and got %v", errEmptyAuthKey, err)
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows to fetch the required token (Org or API) from any given environment variable.

## Motivation and context

This allows implementation to decide which token to use whereas in the previous implementation if an API token was found in MOLLIE_API_TOKEN environment variable then it will always take it as the authentication token which made using Org and API tokens impossible in the same environment.

## How has this been tested?

Unit tests passing.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
