### PR TITLE
add missing struct annotations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+## Project files and directories
+.git
+.github
+docs
+examples
+LICENSE
+.scrutinizer.yml
+.goreleaser.yml
+.gitignore
+.dockerignore
+Dockerfile
+Makefile
+*.md
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Visual Studio Code
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,117 +6,156 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## master
 
+## v2.5.1
+
+### Fixed
+
+- Query tag in ListInvoiceOptions
+
+### Changed
+
+- Upgrade docker to use go1.16-alpine image
+
+### Added
+
+- .dockerignore file
+
 ## v2.5.0
 
 ### Added
+
 - Support for golang v1.16
 
 ## v2.4.0
 
 ### Added
+
 - Permissions API resource
 
 ## v2.3.0
 
 ### Removed
+
 - ING Pay'Home payment method support
 
 ## v2.2.1
 
 ### Added
+
 - User agent header
 
 ### Fixed
+
 - Parse auth key from any given env var
+
 ## v2.2.0
 
 ### Added
+
 - Region fee for payment methods information
 - Status report for payment methods
 
 ## v2.1.2
 
 ### Added
+
 - New category code for marketplace, crowdfunding and donation platforms.
 
 ## v2.1.1
 
 ### Added
+
 - Payment details address for supported payment methods. #109
 
 ## v2.1.0
 
 ## Changed
+
 - Rollback to use pointers inside struct tags as structs have no empty value
-and thus the usage of values instead of pointers breaks most of the post requests.
+  and thus the usage of values instead of pointers breaks most of the post requests.
 
 ## v2.0.2
 
 ### Fixed
+
 - Normalized wording across structs
 
 ## v2.0.1
 
 ### Fixed
+
 - Path for v2 support
 
 ### Deprecated
+
 - v1 support
 
 ## v2.0.0
 
 ### Added
+
 - Missing payment list url options
 
 ### Changed
+
 - Replaced pointers with values in the whole library (BREAKING)
 - All the documentation links name unified to `Documentation`
 
 ## v1.6.5
 
 ### Added
+
 - Goreleaser workflow
 - Examples for subscriptions #96
 - Examples or payment methods
 
 ### Changed
+
 - Renamed ChargebackID to PaymentID in Chargeback struct #98
 
 ## v1.6.4
 
 ### Added
+
 - Full http error content when the response is within the http error range #95
 
 ## v1.6.3
 
 ### Fixed
+
 - Error when parsing amount values on payment methods #94
 
 ## v1.6.2
 
 ### Fixed
+
 - Wrong tag in `MethodOptions`struct #92
 
 ## v1.6.1
 
 ### Fixed
+
 - api token parsing from env variable #89
 - go fmt errors #89
 
 ### Changed
+
 - Updated documentation
 
 ## v1.6.0
 
 ### Changed
-- Go mod version upgraded to 1.15 #86 
+
+- Go mod version upgraded to 1.15 #86
 
 ### Removed
-- Unused variable in refunds.go #87 
+
+- Unused variable in refunds.go #87
 
 ## v1.5.0
 
 ### Added
+
 - Code samples for Chargebacks API #79
 - Playground ready example tests for GetChargeback #79
 - Dockerfile for test execution #81
@@ -125,6 +164,7 @@ and thus the usage of values instead of pointers breaks most of the post request
 - Methods for enabling/disabling payment methods #84
 
 ### Fixed
+
 - golint style errors in `mandates.go` #80
 - ignored error in `newResponse` method is now properly handled #66
 - yaml files were linted #79
@@ -132,46 +172,55 @@ and thus the usage of values instead of pointers breaks most of the post request
 ## v1.4.1
 
 ### Added
+
 - Dashboard URL for payments, profiles, orders, customers and organizations
 
 ### Changed
+
 - Response samples for the aforementioned resources in this tag
 
 ## v1.4.0
 
 ### Added
+
 - ShortDate struct JSON Marshaler
 - Test coverage for the added code
 
 ## v1.3.0
 
 ### Added
+
 - General project housekeeping
 - Added chargebacks as possible embeded value
 
 ## v1.2.1
 
 ### Added
+
 - MandatesID added to Subscriptions resource as follow up to the previous release.
 
 ## v1.2.0
 
 ### Added
+
 - Mandates API resource
 
 ## v1.1.0
 
 ### Added
+
 - Added changes to provide API parity according to mollie's API changelog
 
 ## v1.0.1
 
 ### Fixed
+
 - Fixed error reported when trying to access the `mollie.Error.Response.Body` content (#47).
 
 ## v1.0.0
 
 ### Added
+
 - Base HTTP Client for interacting with Mollie REST API
 - Tests for the added code
 - 8e3130d Added scrutinizer check for code style and coverage
@@ -180,16 +229,18 @@ and thus the usage of values instead of pointers breaks most of the post request
 - f658c63-fixed go linting errors
 - 8893236-methods resource implementation
 
-
 ### Deprecated
+
 - Nothing
 
 ### Changed
+
 - ClientContext for Ctx in APIClient
 - 1a220e4 Improved code comments
 - a089626 Increased code coverage and testing doc examples
 
 ### Fixed
+
 - Missing types for MOLLIE env variables
 - Named variable reference on NewClient method
 - Typos and spelling errors on method's comments
@@ -197,7 +248,9 @@ and thus the usage of values instead of pointers breaks most of the post request
 - Multiple typos and consistency errors
 
 ### Removed
+
 - Nothing
 
 ### Security
+
 - Nothing

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.16
+FROM golang:1.16-alpine
+
+ENV CGO_ENABLED=0
 
 WORKDIR /app
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # mollie
+
 --
-    import "github.com/VictorAvelar/mollie-api-golang/v2/mollie"
+import "github.com/VictorAvelar/mollie-api-golang/v2/mollie"
 
 Package mollie is a wrapper around Mollie's REST API.
 
@@ -28,6 +29,7 @@ const (
 	RequestContentType string = "application/json"
 )
 ```
+
 Constants holding values for client initialization and request instantiation.
 
 ```go
@@ -38,13 +40,15 @@ const (
 	SettlementStatusFailed  = "failed"
 )
 ```
+
 Available settlement statuses
 
-#### func  CheckResponse
+#### func CheckResponse
 
 ```go
 func CheckResponse(r *http.Response) error
 ```
+
 CheckResponse checks the API response for errors, and returns them if present. A
 response is considered an error if it has a status code outside the 200 range.
 API error responses are expected to have either no response body, or a JSON
@@ -181,21 +185,23 @@ type CapturesService service
 
 CapturesService operates over captures resource
 
-#### func (*CapturesService) Get
+#### func (\*CapturesService) Get
 
 ```go
 func (cs *CapturesService) Get(pID, cID string) (c *Capture, err error)
 ```
+
 Get retrieves a single capture by its ID. Note the original payment’s ID is
 needed as well.
 
 See: https://docs.mollie.com/reference/v2/captures-api/get-capture
 
-#### func (*CapturesService) List
+#### func (\*CapturesService) List
 
 ```go
 func (cs *CapturesService) List(pID string) (cl *CapturesList, err error)
 ```
+
 List retrieves all captures for a certain payment
 
 See: https://docs.mollie.com/reference/v2/captures-api/list-captures
@@ -225,6 +231,7 @@ const (
 	Empty          CardLabel = "null"
 )
 ```
+
 Available card labels
 
 #### type CategoryCode
@@ -260,6 +267,7 @@ const (
 	Others                              CategoryCode = 0
 )
 ```
+
 Available category codes
 
 #### type Chargeback
@@ -327,30 +335,33 @@ type ChargebacksService service
 
 ChargebacksService instance operates over chargeback resources
 
-#### func (*ChargebacksService) Get
+#### func (\*ChargebacksService) Get
 
 ```go
 func (cs *ChargebacksService) Get(paymentID, chargebackID string, options *ChargebackOptions) (p Chargeback, err error)
 ```
+
 Get retrieves a single chargeback by its ID. Note the original payment’s ID is
 needed as well.
 
 See: https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
 
-#### func (*ChargebacksService) List
+#### func (\*ChargebacksService) List
 
 ```go
 func (cs *ChargebacksService) List(options *ListChargebackOptions) (cl *ChargebackList, err error)
 ```
+
 List retrieves a list of chargebacks associated with your account/organization.
 
 See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
 
-#### func (*ChargebacksService) ListForPayment
+#### func (\*ChargebacksService) ListForPayment
 
 ```go
 func (cs *ChargebacksService) ListForPayment(paymentID string, options *ListChargebackOptions) (cl *ChargebackList, err error)
 ```
+
 ListForPayment retrieves a list of chargebacks associated with a single payment.
 
 See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
@@ -383,11 +394,12 @@ type Client struct {
 
 Client manages communication with Mollie's API.
 
-#### func  NewClient
+#### func NewClient
 
 ```go
 func NewClient(baseClient *http.Client, c *Config) (mollie *Client, err error)
 ```
+
 NewClient returns a new Mollie HTTP API client. You can pass a previously build
 http client, if none is provided then http.DefaultClient will be used.
 
@@ -398,29 +410,32 @@ to the provided Config object.
 You can also set the token values programmatically by using the Client
 WithAPIKey and WithOrganizationKey functions.
 
-#### func (*Client) Do
+#### func (\*Client) Do
 
 ```go
 func (c *Client) Do(req *http.Request) (*Response, error)
 ```
+
 Do sends an API request and returns the API response or returned as an error if
 an API error has occurred.
 
-#### func (*Client) NewAPIRequest
+#### func (\*Client) NewAPIRequest
 
 ```go
 func (c *Client) NewAPIRequest(method string, uri string, body interface{}) (req *http.Request, err error)
 ```
+
 NewAPIRequest is a wrapper around the http.NewRequest function.
 
 It will setup the authentication headers/parameters according to the client
 config.
 
-#### func (*Client) WithAuthenticationValue
+#### func (\*Client) WithAuthenticationValue
 
 ```go
 func (c *Client) WithAuthenticationValue(k string) error
 ```
+
 WithAuthenticationValue offers a convenient setter for any of the valid
 authentication tokens provided by Mollie.
 
@@ -437,11 +452,12 @@ type Config struct {
 
 Config contains information that helps during the setup of a new Mollie client.
 
-#### func  NewConfig
+#### func NewConfig
 
 ```go
 func NewConfig(t bool, auth string) *Config
 ```
+
 NewConfig builds a Mollie configuration object, it takes t to indicate if our
 client is meant to create requests for testing and auth to indicate the
 authentication method we want to use.
@@ -513,67 +529,74 @@ type CustomersService service
 
 CustomersService operates over the customer resource
 
-#### func (*CustomersService) Create
+#### func (\*CustomersService) Create
 
 ```go
 func (cs *CustomersService) Create(c Customer) (cc *Customer, err error)
 ```
+
 Create creates a simple minimal representation of a customer in the Mollie API
 to use for the Mollie Checkout and Recurring features
 
 See: https://docs.mollie.com/reference/v2/customers-api/create-customer
 
-#### func (*CustomersService) CreatePayment
+#### func (\*CustomersService) CreatePayment
 
 ```go
 func (cs *CustomersService) CreatePayment(id string, p Payment) (pp *Payment, err error)
 ```
+
 CreatePayment creates a payment for the customer.
 
 See: https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
 
-#### func (*CustomersService) Delete
+#### func (\*CustomersService) Delete
 
 ```go
 func (cs *CustomersService) Delete(id string) (err error)
 ```
+
 Delete a customer. All mandates and subscriptions created for this customer will
 be canceled as well.
 
 See: https://docs.mollie.com/reference/v2/customers-api/delete-customer
 
-#### func (*CustomersService) Get
+#### func (\*CustomersService) Get
 
 ```go
 func (cs *CustomersService) Get(id string) (c *Customer, err error)
 ```
+
 Get finds a customer by its ID
 
 See: https://docs.mollie.com/reference/v2/customers-api/get-customer
 
-#### func (*CustomersService) GetPayments
+#### func (\*CustomersService) GetPayments
 
 ```go
 func (cs *CustomersService) GetPayments(id string, options *ListCustomersOptions) (pl *PaymentList, err error)
 ```
+
 GetPayments retrieves all payments linked to the customer.
 
 See: https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
 
-#### func (*CustomersService) List
+#### func (\*CustomersService) List
 
 ```go
 func (cs *CustomersService) List(options *ListCustomersOptions) (cl *CustomersList, err error)
 ```
+
 List retrieves all customers created.
 
 See: https://docs.mollie.com/reference/v2/customers-api/list-customers
 
-#### func (*CustomersService) Update
+#### func (\*CustomersService) Update
 
 ```go
 func (cs *CustomersService) Update(id string, c Customer) (cc *Customer, err error)
 ```
+
 Update mutates an existing customer
 
 See: https://docs.mollie.com/reference/v2/customers-api/update-customer
@@ -597,6 +620,7 @@ const (
 	ActiveFraudControlUnAuthPremium EligibilityReasons = "Active Fraud Control - Unauth Premium Eligible"
 )
 ```
+
 Available eligibility reasons for Paypal sellers protection
 
 #### type EmbedValue
@@ -615,6 +639,7 @@ const (
 	EmbedChangebacks EmbedValue = "chanrgebacks"
 )
 ```
+
 Valid Embed query string value.
 
 #### type Error
@@ -630,11 +655,12 @@ type Error struct {
 
 Error reports details on a failed API request.
 
-#### func (*Error) Error
+#### func (\*Error) Error
 
 ```go
 func (e *Error) Error() string
 ```
+
 Error function complies with the error interface
 
 #### type FailureReason
@@ -659,6 +685,7 @@ const (
 	ReasonPossibleFraud         FailureReason = "possible_fraud"
 )
 ```
+
 Possible failure reasons
 
 #### type FeeRegion
@@ -678,6 +705,7 @@ const (
 	Other           FeeRegion = "other"
 )
 ```
+
 Valid Fee regions
 
 #### type GiftCardEnabled
@@ -727,6 +755,7 @@ const (
 	Yourgift                   GiftCardIssuer = "yourgift"
 )
 ```
+
 Supported gift card issuers
 
 #### type GiftCardIssuerStatus
@@ -743,6 +772,7 @@ const (
 	EnabledIssuer GiftCardIssuerStatus = "enabled"
 )
 ```
+
 Valid issuer statuses
 
 #### type GiftCardLinks
@@ -832,6 +862,7 @@ const (
 	InvoiceStatusOverdue InvoiceStatus = "overdue"
 )
 ```
+
 Valid status of the invoice
 
 #### type InvoicesService
@@ -842,18 +873,20 @@ type InvoicesService service
 
 InvoicesService instance operates over invoice resources
 
-#### func (*InvoicesService) Get
+#### func (\*InvoicesService) Get
 
 ```go
 func (is *InvoicesService) Get(id string) (i Invoice, err error)
 ```
+
 Get retrieve details of an invoice, using the invoice’s identifier.
 
-#### func (*InvoicesService) List
+#### func (\*InvoicesService) List
 
 ```go
 func (is *InvoicesService) List(options *ListInvoiceOptions) (il InvoiceList, err error)
 ```
+
 List retrieves a list of invoices associated with your account/organization.
 
 #### type LineItem
@@ -902,10 +935,10 @@ endpoint.
 
 ```go
 type ListInvoiceOptions struct {
-	Reference string `json:"reference,omitempty"`
-	Year      string `json:"year,omitempty"`
-	From      string `json:"from,omitempty"`
-	Limit     int64  `json:"limit,omitempty"`
+	Reference string `url:"reference,omitempty"`
+	Year      string `url:"year,omitempty"`
+	From      string `url:"from,omitempty"`
+	Limit     int64  `url:"limit,omitempty"`
 }
 ```
 
@@ -1002,6 +1035,7 @@ const (
 	Lithuanian    Locale = "lt_LT"
 )
 ```
+
 Mollie supported locales
 
 #### type Mandate
@@ -1085,6 +1119,7 @@ const (
 	InvalidMandate MandateStatus = "invalid"
 )
 ```
+
 Valid mandate statuses
 
 #### type MandatesService
@@ -1095,41 +1130,45 @@ type MandatesService service
 
 MandatesService operates over customer mandates endpoints.
 
-#### func (*MandatesService) Create
+#### func (\*MandatesService) Create
 
 ```go
 func (ms *MandatesService) Create(cID string, mandate Mandate) (mr *Mandate, err error)
 ```
+
 Create a mandate for a specific customer. Mandates allow you to charge a
 customer’s credit card or bank account recurrently.
 
 See: https://docs.mollie.com/reference/v2/mandates-api/create-mandate
 
-#### func (*MandatesService) Get
+#### func (\*MandatesService) Get
 
 ```go
 func (ms *MandatesService) Get(cID, mID string) (mr *Mandate, err error)
 ```
+
 Get retrieves a mandate by its ID and its customer’s ID. The mandate will either
 contain IBAN or credit card details, depending on the type of mandate.
 
 See: https://docs.mollie.com/reference/v2/mandates-api/get-mandate
 
-#### func (*MandatesService) List
+#### func (\*MandatesService) List
 
 ```go
 func (ms *MandatesService) List(cID string, opt *ListMandatesOptions) (ml MandateList, err error)
 ```
+
 List retrieves all mandates for the given customerId, ordered from newest to
 oldest.
 
 See: https://docs.mollie.com/reference/v2/mandates-api/list-mandates
 
-#### func (*MandatesService) Revoke
+#### func (\*MandatesService) Revoke
 
 ```go
 func (ms *MandatesService) Revoke(cID, mID string) (err error)
 ```
+
 Revoke a customer’s mandate. You will no longer be able to charge the consumer’s
 bank account or credit card with this mandate and all connected subscriptions
 will be canceled.
@@ -1176,31 +1215,34 @@ type MethodsService service
 
 MethodsService operates on methods endpoints
 
-#### func (*MethodsService) All
+#### func (\*MethodsService) All
 
 ```go
 func (ms *MethodsService) All(options *MethodsOptions) (pm *ListMethods, err error)
 ```
+
 All retrieves all the payment methods enabled for your account/organization
 
 See: https://docs.mollie.com/reference/v2/methods-api/list-all-methods
 
-#### func (*MethodsService) Get
+#### func (\*MethodsService) Get
 
 ```go
 func (ms *MethodsService) Get(id string, options *MethodsOptions) (pmi *PaymentMethodInfo, err error)
 ```
+
 Get returns information about the payment method specified by id, it also
 receives a pointer to the method options containing applicable query string
 parameters
 
 See: https://docs.mollie.com/reference/v2/methods-api/get-method
 
-#### func (*MethodsService) List
+#### func (\*MethodsService) List
 
 ```go
 func (ms *MethodsService) List(options *MethodsOptions) (pm *ListMethods, err error)
 ```
+
 List retrieves all enabled payment methods. The results are not paginated.
 
 See: https://docs.mollie.com/reference/v2/methods-api/list-methods
@@ -1214,11 +1256,12 @@ type MiscellaneousService service
 MiscellaneousService operates over the resources described in Mollie's
 miscellaneous API endpoints section
 
-#### func (*MiscellaneousService) ApplePaymentSession
+#### func (\*MiscellaneousService) ApplePaymentSession
 
 ```go
 func (ms *MiscellaneousService) ApplePaymentSession(asr *ApplePaymentSessionRequest) (aps *ApplePaymentSession, err error)
 ```
+
 ApplePaymentSession returns an Apple Payment Session object valid for one
 transaction.
 
@@ -1239,6 +1282,7 @@ const (
 	TestMode Mode = "test"
 )
 ```
+
 Valid modes
 
 #### type Order
@@ -1373,6 +1417,7 @@ const (
 	OrderLineCompleted  OrderLineStatus = "completed"
 )
 ```
+
 Valid order line status.
 
 #### type OrderLinks
@@ -1492,6 +1537,7 @@ const (
 	Expired    OrderStatus = "expired"
 )
 ```
+
 Valid order status.
 
 #### type OrdersService
@@ -1502,93 +1548,103 @@ type OrdersService service
 
 OrdersService instance operates over refund resources.
 
-#### func (*OrdersService) Cancel
+#### func (\*OrdersService) Cancel
 
 ```go
 func (ors *OrdersService) Cancel(orderID string) (order *Order, err error)
 ```
+
 Cancel try to cancel the order that fulfill certain requirements.
 
 See https://docs.mollie.com/reference/v2/orders-api/cancel-order
 
-#### func (*OrdersService) CancelOrderLines
+#### func (\*OrdersService) CancelOrderLines
 
 ```go
 func (ors *OrdersService) CancelOrderLines(orderID string, orderLines []OrderLine) (err error)
 ```
+
 CancelOrderLines can be used to cancel one or more order lines that were
 previously authorized using a pay after delivery payment method. Use the Cancel
 Order API if you want to cancel the entire order or the remainder of the order.
 
 See https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
 
-#### func (*OrdersService) Create
+#### func (\*OrdersService) Create
 
 ```go
 func (ors *OrdersService) Create(ord Order, opt *OrderOptions) (order *Order, err error)
 ```
+
 Create an order will automatically create the required payment to allow your
 customer to pay for the order.
 
 See https://docs.mollie.com/reference/v2/orders-api/create-order
 
-#### func (*OrdersService) CreateOrderPayment
+#### func (\*OrdersService) CreateOrderPayment
 
 ```go
 func (ors *OrdersService) CreateOrderPayment(orderID string, ordPay *OrderPayment) (payment *Payment, err error)
 ```
+
 CreateOrderPayment can only be created while the status of the order is created,
 and when the status of the existing payment is either expired, canceled or
 failed. See https://docs.mollie.com/reference/v2/orders-api/create-order-payment
 
-#### func (*OrdersService) CreateOrderRefund
+#### func (\*OrdersService) CreateOrderRefund
 
 ```go
 func (ors *OrdersService) CreateOrderRefund(orderID string, order *Order) (refund Refund, err error)
 ```
+
 CreateOrderRefund using the Orders API, refunds should be made against the
 order. See https://docs.mollie.com/reference/v2/orders-api/create-order-refund
 
-#### func (*OrdersService) Get
+#### func (\*OrdersService) Get
 
 ```go
 func (ors *OrdersService) Get(orID string, opt *OrderOptions) (order *Order, err error)
 ```
+
 Get retrieve a single order by its ID.
 
 See https://docs.mollie.com/reference/v2/orders-api/get-order
 
-#### func (*OrdersService) List
+#### func (\*OrdersService) List
 
 ```go
 func (ors *OrdersService) List(opt *OrderListOptions) (ordList *OrderList, err error)
 ```
+
 List is to retrieve all orders.
 
 See https://docs.mollie.com/reference/v2/orders-api/list-orders
 
-#### func (*OrdersService) ListOrderRefunds
+#### func (\*OrdersService) ListOrderRefunds
 
 ```go
 func (ors *OrdersService) ListOrderRefunds(orderID string, opt *OrderListRefundOptions) (orderListRefund OrderListRefund, err error)
 ```
+
 ListOrderRefunds retrieve all order refunds. See
 https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
 
-#### func (*OrdersService) Update
+#### func (\*OrdersService) Update
 
 ```go
 func (ors *OrdersService) Update(orderID string, ord Order) (order *Order, err error)
 ```
+
 Update is used to update the billing and/or shipping address of an order.
 
 See https://docs.mollie.com/reference/v2/orders-api/update-order
 
-#### func (*OrdersService) UpdateOrderLine
+#### func (\*OrdersService) UpdateOrderLine
 
 ```go
 func (ors *OrdersService) UpdateOrderLine(orderID string, orderLineID string, orderLine OrderLine) (order *Order, err error)
 ```
+
 UpdateOrderLine can be used to update an order line.
 
 See https://docs.mollie.com/reference/v2/orders-api/update-orderline
@@ -1640,18 +1696,20 @@ type OrganizationsService service
 
 OrganizationsService instance operates over organization resources
 
-#### func (*OrganizationsService) Get
+#### func (\*OrganizationsService) Get
 
 ```go
 func (os *OrganizationsService) Get(id string) (o *Organization, err error)
 ```
+
 Get retrieve an organization by its id.
 
-#### func (*OrganizationsService) GetCurrent
+#### func (\*OrganizationsService) GetCurrent
 
 ```go
 func (os *OrganizationsService) GetCurrent() (o *Organization, err error)
 ```
+
 GetCurrent retrieve the currently authenticated organization
 
 #### type PaginationLinks
@@ -1850,6 +1908,7 @@ const (
 	Sofort         PaymentMethod = "sofort"
 )
 ```
+
 Supported payment methods
 
 #### type PaymentMethodInfo
@@ -1902,6 +1961,7 @@ const (
 	PaymentMethodRejected        PaymentMethodStatus = "pending-rejected"
 )
 ```
+
 Available payment method statuses
 
 #### type PaymentOptions
@@ -1925,45 +1985,50 @@ type PaymentsService service
 
 PaymentsService instance operates over payment resources
 
-#### func (*PaymentsService) Cancel
+#### func (\*PaymentsService) Cancel
 
 ```go
 func (ps *PaymentsService) Cancel(id string) (p Payment, err error)
 ```
+
 Cancel removes a payment (if possible) from your Mollie account.
 
 See: https://docs.mollie.com/reference/v2/payments-api/cancel-payment
 
-#### func (*PaymentsService) Create
+#### func (\*PaymentsService) Create
 
 ```go
 func (ps *PaymentsService) Create(p Payment) (np Payment, err error)
 ```
+
 Create stores a new payment object attached to your Mollie account.
 
 See: https://docs.mollie.com/reference/v2/payments-api/create-payment#
 
-#### func (*PaymentsService) Get
+#### func (\*PaymentsService) Get
 
 ```go
 func (ps *PaymentsService) Get(id string, options *PaymentOptions) (p Payment, err error)
 ```
+
 Get retrieves a single payment object by its payment token.
 
-#### func (*PaymentsService) List
+#### func (\*PaymentsService) List
 
 ```go
 func (ps *PaymentsService) List(options *ListPaymentOptions) (pl PaymentList, err error)
 ```
+
 List retrieves a list of payments associated with your account/organization.
 
 See: https://docs.mollie.com/reference/v2/payments-api/list-payments
 
-#### func (*PaymentsService) Update
+#### func (\*PaymentsService) Update
 
 ```go
 func (ps *PaymentsService) Update(id string, up Payment) (p Payment, err error)
 ```
+
 Update can be used to update some details of a created payment.
 
 See: https://docs.mollie.com/reference/v2/payments-api/update-payment#
@@ -2015,6 +2080,7 @@ const (
 	OnboardingWrite    PermissionGrant = "onbording.write"
 )
 ```
+
 Available permission grants.
 
 #### type PermissionLinks
@@ -2051,20 +2117,22 @@ type PermissionsService service
 
 PermissionsService operates over permission resources.
 
-#### func (*PermissionsService) Get
+#### func (\*PermissionsService) Get
 
 ```go
 func (ps *PermissionsService) Get(id string) (p *Permission, err error)
 ```
+
 Get returns a permission by its id.
 
 See: https://docs.mollie.com/reference/v2/permissions-api/get-permission
 
-#### func (*PermissionsService) List
+#### func (\*PermissionsService) List
 
 ```go
 func (ps *PermissionsService) List() (pl *PermissionsList, err error)
 ```
+
 List retrieves all permissions available with the current app access token. The
 list is not paginated.
 
@@ -2098,6 +2166,7 @@ const (
 	Surcharge       ProductType = "surcharge"
 )
 ```
+
 Valid product type.
 
 #### type Profile
@@ -2181,6 +2250,7 @@ const (
 	StatusBlocked    ProfileStatus = "blocked"
 )
 ```
+
 Possible profile statuses
 
 #### type ProfilesService
@@ -2191,104 +2261,116 @@ type ProfilesService service
 
 ProfilesService operates over profile resource
 
-#### func (*ProfilesService) Create
+#### func (\*ProfilesService) Create
 
 ```go
 func (ps *ProfilesService) Create(np *Profile) (p *Profile, err error)
 ```
+
 Create stores a new profile in your Mollie account.
 
-#### func (*ProfilesService) Current
+#### func (\*ProfilesService) Current
 
 ```go
 func (ps *ProfilesService) Current() (p *Profile, err error)
 ```
+
 Current returns the profile belonging to the API key. This method only works
 when using API keys.
 
-#### func (*ProfilesService) Delete
+#### func (\*ProfilesService) Delete
 
 ```go
 func (ps *ProfilesService) Delete(id string) (err error)
 ```
+
 Delete enables profile deletions, rendering the profile unavailable for further
 API calls and transactions.
 
-#### func (*ProfilesService) DisableGiftCardIssuer
+#### func (\*ProfilesService) DisableGiftCardIssuer
 
 ```go
 func (ps *ProfilesService) DisableGiftCardIssuer(profileID string, issuer GiftCardIssuer) (err error)
 ```
+
 DisableGiftCardIssuer deactivates the requested giftcard issuer for the provided
 profile id.
 
 See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
 
-#### func (*ProfilesService) DisableGiftCardIssuerForCurrent
+#### func (\*ProfilesService) DisableGiftCardIssuerForCurrent
 
 ```go
 func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(issuer GiftCardIssuer) (err error)
 ```
+
 DisableGiftCardIssuerForCurrent deactivates the specified issuer for the curent
 profile (token owner).
 
 See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
 
-#### func (*ProfilesService) DisablePaymentMethod
+#### func (\*ProfilesService) DisablePaymentMethod
 
 ```go
 func (ps *ProfilesService) DisablePaymentMethod(id string, pm PaymentMethod) (err error)
 ```
+
 DisablePaymentMethod disables a payment method on a specific or authenticated
 profile. If you're using API tokens for authentication, pass "me" as id.
 
-#### func (*ProfilesService) EnableGiftCardIssuer
+#### func (\*ProfilesService) EnableGiftCardIssuer
 
 ```go
 func (ps *ProfilesService) EnableGiftCardIssuer(profileID string, issuer GiftCardIssuer) (gc *GiftCardEnabled, err error)
 ```
+
 EnableGiftCardIssuer activates the requested giftcard issuer for the provided
 profile id.
 
 See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
 
-#### func (*ProfilesService) EnableGiftCardIssuerForCurrent
+#### func (\*ProfilesService) EnableGiftCardIssuerForCurrent
 
 ```go
 func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(issuer GiftCardIssuer) (gc *GiftCardEnabled, err error)
 ```
+
 EnableGiftCardIssuerForCurrent activates the specified issuer for the curent
 profile (token owner).
 
 See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
 
-#### func (*ProfilesService) EnablePaymentMethod
+#### func (\*ProfilesService) EnablePaymentMethod
 
 ```go
 func (ps *ProfilesService) EnablePaymentMethod(id string, pm PaymentMethod) (pmi *PaymentMethodInfo, err error)
 ```
+
 EnablePaymentMethod enables a payment method on a specific or authenticated
 profile. If you're using API tokens for authentication, pass "me" as id.
 
-#### func (*ProfilesService) Get
+#### func (\*ProfilesService) Get
 
 ```go
 func (ps *ProfilesService) Get(id string) (p *Profile, err error)
 ```
+
 Get retrieves the a profile by ID.
 
-#### func (*ProfilesService) List
+#### func (\*ProfilesService) List
 
 ```go
 func (ps *ProfilesService) List(options *ProfileListOptions) (pl *ProfileList, err error)
 ```
+
 List returns all the profiles for the authenticated account
 
-#### func (*ProfilesService) Update
+#### func (\*ProfilesService) Update
 
 ```go
 func (ps *ProfilesService) Update(id string, up *Profile) (p *Profile, err error)
 ```
+
 Update allows you to perform mutations on a profile
 
 #### type QRCode
@@ -2394,6 +2476,7 @@ const (
 	Failed     RefundStatus = "failed"
 )
 ```
+
 Valid refund status.
 
 #### type RefundsService
@@ -2404,48 +2487,53 @@ type RefundsService service
 
 RefundsService instance operates over refund resources.
 
-#### func (*RefundsService) Cancel
+#### func (\*RefundsService) Cancel
 
 ```go
 func (rs *RefundsService) Cancel(paymentID, refundID string, options *RefundOptions) (err error)
 ```
+
 Cancel try to cancel the refund request. The refund can only be canceled while
 the refund’s status is either queued or pending. See
 https://docs.mollie.com/reference/v2/refunds-api/cancel-refund
 
-#### func (*RefundsService) Create
+#### func (\*RefundsService) Create
 
 ```go
 func (rs *RefundsService) Create(paymentID string, re Refund, options *RefundOptions) (rf Refund, err error)
 ```
+
 Create a refund payment request.
 
 See https://docs.mollie.com/reference/v2/refunds-api/create-refund.
 
-#### func (*RefundsService) Get
+#### func (\*RefundsService) Get
 
 ```go
 func (rs *RefundsService) Get(paymentID, refundID string, options *RefundOptions) (refund Refund, err error)
 ```
+
 Get retrieve a single refund by its ID.
 
 If you do not know the original payment’s ID, you can use the List payment
 refunds endpoint.
 
-#### func (*RefundsService) ListRefund
+#### func (\*RefundsService) ListRefund
 
 ```go
 func (rs *RefundsService) ListRefund(options *ListRefundOptions) (rl *RefundList, err error)
 ```
+
 ListRefund calls the top level https://api.mollie.com/v2/refunds.
 
 See https://docs.mollie.com/reference/v2/refunds-api/list-refunds.
 
-#### func (*RefundsService) ListRefundPayment
+#### func (\*RefundsService) ListRefundPayment
 
 ```go
 func (rs *RefundsService) ListRefundPayment(paymentID string, options *ListRefundOptions) (rl *RefundList, err error)
 ```
+
 ListRefundPayment calls the payment-specific
 https://api.mollie.com/v2/payments/*paymentId*/refunds. Only refunds for that
 specific payment are returned. See
@@ -2478,6 +2566,7 @@ const (
 	RecurringSequence SequenceType = "recurring"
 )
 ```
+
 Valid sequence types
 
 #### type Settlement
@@ -2609,79 +2698,87 @@ type SettlementsService service
 
 SettlementsService operates over settlements resource
 
-#### func (*SettlementsService) Get
+#### func (\*SettlementsService) Get
 
 ```go
 func (ss *SettlementsService) Get(id string) (s *Settlement, err error)
 ```
+
 Get returns a settlement by its id or the bank reference id
 
 See: https://docs.mollie.com/reference/v2/settlements-api/get-settlement
 
-#### func (*SettlementsService) GetCaptures
+#### func (\*SettlementsService) GetCaptures
 
 ```go
 func (ss *SettlementsService) GetCaptures(id string, slo *SettlementsListOptions) (cl *CapturesList, err error)
 ```
+
 GetCaptures retrieves all captures included in a settlement.
 
 See:
 https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
 
-#### func (*SettlementsService) GetChargebacks
+#### func (\*SettlementsService) GetChargebacks
 
 ```go
 func (ss *SettlementsService) GetChargebacks(id string, slo *SettlementsListOptions) (cl *ChargebackList, err error)
 ```
+
 GetChargebacks retrieves all chargebacks included in a settlement.
 
 See:
 https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
 
-#### func (*SettlementsService) GetPayments
+#### func (\*SettlementsService) GetPayments
 
 ```go
 func (ss *SettlementsService) GetPayments(id string, slo *SettlementsListOptions) (pl *PaymentList, err error)
 ```
+
 GetPayments retrieves all payments included in a settlement.
 
 See:
 https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
 
-#### func (*SettlementsService) GetRefunds
+#### func (\*SettlementsService) GetRefunds
 
 ```go
 func (ss *SettlementsService) GetRefunds(id string, slo *SettlementsListOptions) (rl *RefundList, err error)
 ```
+
 GetRefunds retrieves all refunds included in a settlement.
 
 See:
 https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
 
-#### func (*SettlementsService) List
+#### func (\*SettlementsService) List
 
 ```go
 func (ss *SettlementsService) List(slo *SettlementsListOptions) (sl *SettlementsList, err error)
 ```
+
 List retrieves all settlements, ordered from new to old
 
 See: https://docs.mollie.com/reference/v2/settlements-api/list-settlements
 
-#### func (*SettlementsService) Next
+#### func (\*SettlementsService) Next
 
 ```go
 func (ss *SettlementsService) Next() (s *Settlement, err error)
 ```
+
 Next retrieves the details of the current settlement that has not yet been paid
 out.
 
 See: https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement
 
-#### func (*SettlementsService) Open
+#### func (\*SettlementsService) Open
 
 ```go
 func (ss *SettlementsService) Open() (s *Settlement, err error)
 ```
+
 Open retrieves the details of the open balance of the organization. This will
 return a settlement object representing your organization’s balance.
 
@@ -2752,38 +2849,42 @@ type ShipmentsService service
 
 ShipmentsService operates on shipments endpoints.
 
-#### func (*ShipmentsService) Create
+#### func (\*ShipmentsService) Create
 
 ```go
 func (ss *ShipmentsService) Create(oID string, cs CreateShipmentRequest) (s *Shipment, err error)
 ```
+
 Create can be used to ship order lines.
 
 See: https://docs.mollie.com/reference/v2/shipments-api/create-shipment
 
-#### func (*ShipmentsService) Get
+#### func (\*ShipmentsService) Get
 
 ```go
 func (ss *ShipmentsService) Get(oID string, sID string) (s *Shipment, err error)
 ```
+
 Get retrieves a single shipment and the order lines shipped by a shipment’s ID.
 
 See: https://docs.mollie.com/reference/v2/shipments-api/get-shipment#
 
-#### func (*ShipmentsService) List
+#### func (\*ShipmentsService) List
 
 ```go
 func (ss *ShipmentsService) List(oID string) (sl *ShipmentsList, err error)
 ```
+
 List retrieves all shipments for an order.
 
 See: https://docs.mollie.com/reference/v2/shipments-api/list-shipments
 
-#### func (*ShipmentsService) Update
+#### func (\*ShipmentsService) Update
 
 ```go
 func (ss *ShipmentsService) Update(oID string, sID string, st ShipmentTracking) (s *Shipment, err error)
 ```
+
 Update can be used to update the tracking information of a shipment
 
 See: https://docs.mollie.com/reference/v2/shipments-api/update-shipment
@@ -2798,19 +2899,21 @@ type ShortDate struct {
 
 ShortDate is a string representing a date in YYYY-MM-DD format.
 
-#### func (*ShortDate) MarshalJSON
+#### func (\*ShortDate) MarshalJSON
 
 ```go
 func (d *ShortDate) MarshalJSON() ([]byte, error)
 ```
+
 MarshalJSON overrides the default marshal action for the Date struct. Returns
 date as YYYY-MM-DD formatted string.
 
-#### func (*ShortDate) UnmarshalJSON
+#### func (\*ShortDate) UnmarshalJSON
 
 ```go
 func (d *ShortDate) UnmarshalJSON(b []byte) error
 ```
+
 UnmarshalJSON overrides the default unmarshal action for the Date struct, as we
 need links to be pointers to the time.Time struct.
 
@@ -2899,6 +3002,7 @@ const (
 	SubscriptionStatusCompleted SubscriptionStatus = "completed"
 )
 ```
+
 Available subscription statuses
 
 #### type SubscriptionsService
@@ -2909,11 +3013,12 @@ type SubscriptionsService service
 
 SubscriptionsService operates over subscriptions resource
 
-#### func (*SubscriptionsService) All
+#### func (\*SubscriptionsService) All
 
 ```go
 func (ss *SubscriptionsService) All(options *SubscriptionListOptions) (sl *SubscriptionList, err error)
 ```
+
 All retrieves all subscriptions, ordered from newest to oldest. By using an API
 key all the subscriptions created with the current website profile will be
 returned. In the case of an OAuth Access Token relies the website profile on the
@@ -2922,57 +3027,63 @@ profileId field
 See:
 https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
 
-#### func (*SubscriptionsService) Create
+#### func (\*SubscriptionsService) Create
 
 ```go
 func (ss *SubscriptionsService) Create(cID string, sc *Subscription) (s *Subscription, err error)
 ```
+
 Create stores a new subscription for a given customer
 
 See: https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
 
-#### func (*SubscriptionsService) Delete
+#### func (\*SubscriptionsService) Delete
 
 ```go
 func (ss *SubscriptionsService) Delete(cID, sID string) (s *Subscription, err error)
 ```
+
 Delete cancels a subscription
 
 See: https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
 
-#### func (*SubscriptionsService) Get
+#### func (\*SubscriptionsService) Get
 
 ```go
 func (ss *SubscriptionsService) Get(cID, sID string) (s *Subscription, err error)
 ```
+
 Get retrieves a customer's subscription
 
 See: https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
 
-#### func (*SubscriptionsService) GetPayments
+#### func (\*SubscriptionsService) GetPayments
 
 ```go
 func (ss *SubscriptionsService) GetPayments(cID, sID string, options *SubscriptionListOptions) (sl *PaymentList, err error)
 ```
+
 GetPayments retrieves all payments of a specific subscriptions of a customer
 
 See:
 https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
 
-#### func (*SubscriptionsService) List
+#### func (\*SubscriptionsService) List
 
 ```go
 func (ss *SubscriptionsService) List(cID string, options *SubscriptionListOptions) (sl *SubscriptionList, err error)
 ```
+
 List retrieves all subscriptions of a customer
 
 See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
 
-#### func (*SubscriptionsService) Update
+#### func (\*SubscriptionsService) Update
 
 ```go
 func (ss *SubscriptionsService) Update(cID, sID string, sc *Subscription) (s *Subscription, err error)
 ```
+
 Update changes fields on a subscription object
 
 See: https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription

--- a/mollie/invoices.go
+++ b/mollie/invoices.go
@@ -54,10 +54,10 @@ type InvoiceLinks struct {
 
 // ListInvoiceOptions describes list invoices endpoint valid query string parameters.
 type ListInvoiceOptions struct {
-	Reference string `json:"reference,omitempty"`
-	Year      string `json:"year,omitempty"`
-	From      string `json:"from,omitempty"`
-	Limit     int64  `json:"limit,omitempty"`
+	Reference string `url:"reference,omitempty"`
+	Year      string `url:"year,omitempty"`
+	From      string `url:"from,omitempty"`
+	Limit     int64  `url:"limit,omitempty"`
 }
 
 // InvoiceList describes how a list of invoices will be retrieved by Mollie.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds missing struct annotations to parse ListInvoiceOptions values to a good representation of query parameters when requesting invoices for a profile/organization.

## Motivation and context

The tags were missing a that cause some requests to fail when attempting to filter the list invoice result set.

## How has this been tested?

Please describe in detail how you tested your changes.

Existing tests passing.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
