### PR TITLE
Remove custom out format

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,4 +41,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.29
-          args: --issues-exit-code=0 --out-format=github-actions --new=true --sort-results --skip-dirs-use-default --tests=false
+          args: --issues-exit-code=0 --new=true --sort-results --skip-dirs-use-default --tests=false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes custom out format for golangci-lint workflow.