### PR TITLE
Add issuers to payment method info

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2057,12 +2057,27 @@ type PaymentMethodInfo struct {
 	MaximumAmount *Amount                 `json:"maximumAmount,omitempty"`
 	Image         *Image                  `json:"image,omitempty"`
 	Pricing       []*PaymentMethodPricing `json:"pricing,omitempty"`
+	Issuers       []*PaymentMethodIssuer  `json:"issuers,omitempty"`
 	Status        *PaymentMethodStatus    `json:"status,omitempty"`
 	Links         MethodsLinks            `json:"_links,omitempty"`
 }
 ```
 
 PaymentMethodInfo describes a single method with details.
+
+#### type PaymentMethodIssuer
+
+```go
+type PaymentMethodIssuer struct {
+	Resource string `json:"resource,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Image    Image  `json:"image,omitempty"`
+}
+```
+
+PaymentMethodIssuer available for the payment method (for iDEAL, KBC/CBC payment
+button, gift cards, or meal vouchers).
 
 #### type PaymentMethodPricing
 

--- a/mollie/methods.go
+++ b/mollie/methods.go
@@ -31,6 +31,7 @@ type PaymentMethodInfo struct {
 	MaximumAmount *Amount                 `json:"maximumAmount,omitempty"`
 	Image         *Image                  `json:"image,omitempty"`
 	Pricing       []*PaymentMethodPricing `json:"pricing,omitempty"`
+	Issuers       []*PaymentMethodIssuer  `json:"issuers,omitempty"`
 	Status        *PaymentMethodStatus    `json:"status,omitempty"`
 	Links         MethodsLinks            `json:"_links,omitempty"`
 }
@@ -55,6 +56,15 @@ type PaymentMethodPricing struct {
 	Fixed       *Amount   `json:"fixed,omitempty"`
 	Variable    string    `json:"variable,omitempty"`
 	FeeRegion   FeeRegion `json:"feeRegion,omitempty"`
+}
+
+// PaymentMethodIssuer available for the payment method
+// (for iDEAL, KBC/CBC payment button, gift cards, or meal vouchers).
+type PaymentMethodIssuer struct {
+	Resource string `json:"resource,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Image    Image  `json:"image,omitempty"`
 }
 
 // ListMethods describes a list of paginated payment methods.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The payment info struct was lacking the possibility to parse Payment Method Issuers for payment methods such as IDEAL, this made impossible for the client to parse the values from the original api call which made the library harder to work with.

## Motivation and context

Closes #136 

## How has this been tested?

Existing tests working, manual testing and CI pipeline execution.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
