### PR TITLE
Add payment query options receiver for create payment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2148,7 +2148,7 @@ See: https://docs.mollie.com/reference/v2/payments-api/cancel-payment
 #### func (\*PaymentsService) Create
 
 ```go
-func (ps *PaymentsService) Create(p Payment) (np Payment, err error)
+func (ps *PaymentsService) Create(p Payment, options *PaymentOptions) (np Payment, err error)
 ```
 
 Create stores a new payment object attached to your Mollie account.

--- a/mollie/payments.go
+++ b/mollie/payments.go
@@ -160,8 +160,12 @@ func (ps *PaymentsService) Get(id string, options *PaymentOptions) (p Payment, e
 // Create stores a new payment object attached to your Mollie account.
 //
 // See: https://docs.mollie.com/reference/v2/payments-api/create-payment#
-func (ps *PaymentsService) Create(p Payment) (np Payment, err error) {
+func (ps *PaymentsService) Create(p Payment, options *PaymentOptions) (np Payment, err error) {
 	u := "v2/payments"
+	if options != nil {
+		v, _ := query.Values(options)
+		u = fmt.Sprintf("%s?%s", u, v.Encode())
+	}
 
 	if ps.client.HasAccessToken() && ps.client.config.testing {
 		p.TestMode = true

--- a/mollie/payments_test.go
+++ b/mollie/payments_test.go
@@ -63,7 +63,7 @@ func TestPaymentsService_Create(t *testing.T) {
 		Description: "Order #12345",
 	}
 
-	res, err := tClient.Payments.Create(p)
+	res, err := tClient.Payments.Create(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestPaymentsService_Create_AccessTokens(t *testing.T) {
 		Description: "Order #12345",
 	}
 
-	payment, err := tClient.Payments.Create(p)
+	payment, err := tClient.Payments.Create(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestPaymentsService_Create_PaymentMethodFields(t *testing.T) {
 		Issuer:      "ideal_INGBNL2A",
 	}
 
-	payment, err := tClient.Payments.Create(p)
+	payment, err := tClient.Payments.Create(p, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestPaymentsService_HttpRequestErrors(t *testing.T) {
 		Description: "Order #12345",
 	}
 
-	_, cerr := tClient.Payments.Create(p)
+	_, cerr := tClient.Payments.Create(p, nil)
 	_, rerr := tClient.Payments.List(nil)
 	_, uerr := tClient.Payments.Update("1212", p)
 	_, derr := tClient.Payments.Cancel("1212")
@@ -304,7 +304,7 @@ func TestPaymentsService_NewAPIRequestErrors(t *testing.T) {
 		Description: "Order #12345",
 	}
 
-	_, cerr := tClient.Payments.Create(p)
+	_, cerr := tClient.Payments.Create(p, nil)
 	_, rerr := tClient.Payments.List(nil)
 	_, uerr := tClient.Payments.Update("1212", p)
 	_, derr := tClient.Payments.Cancel("1212")
@@ -332,7 +332,7 @@ func TestPaymentsService_EncodingResponseErrors(t *testing.T) {
 		Description: "Order #12345",
 	}
 
-	_, cerr := tClient.Payments.Create(p)
+	_, cerr := tClient.Payments.Create(p, nil)
 	_, rerr := tClient.Payments.List(nil)
 	_, uerr := tClient.Payments.Update("1212", p)
 	_, derr := tClient.Payments.Cancel("1212")
@@ -354,7 +354,7 @@ func TestPaymentFailedResponseAvailable(t *testing.T) {
 	defer teardown()
 	tMux.HandleFunc("/v2/payments/", unprocessableEntityHandler)
 
-	_, err := tClient.Payments.Create(Payment{})
+	_, err := tClient.Payments.Create(Payment{}, nil)
 
 	if err == nil {
 		t.Error("expected error and got nil")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a receiver for specifying query parameters when using `Payment.Create()` action.

This is to be able to specify that a qr code for the payment should also be created and retrieved.

## Motivation and context

Closes #138 

## How has this been tested?

Existing test suite passing.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
