### PR TITLE
Adding net/url PathEscape to string variables

### DIFF
--- a/mollie/captures.go
+++ b/mollie/captures.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -48,7 +49,7 @@ type CapturesList struct {
 //
 // See: https://docs.mollie.com/reference/v2/captures-api/get-capture
 func (cs *CapturesService) Get(pID, cID string) (c *Capture, err error) {
-	u := fmt.Sprintf("v2/payments/%s/captures/%s", pID, cID)
+	u := fmt.Sprintf("v2/payments/%s/captures/%s", url.PathEscape(pID), url.PathEscape(cID))
 	req, err := cs.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return
@@ -69,7 +70,7 @@ func (cs *CapturesService) Get(pID, cID string) (c *Capture, err error) {
 //
 // See: https://docs.mollie.com/reference/v2/captures-api/list-captures
 func (cs *CapturesService) List(pID string) (cl *CapturesList, err error) {
-	u := fmt.Sprintf("v2/payments/%s/captures", pID)
+	u := fmt.Sprintf("v2/payments/%s/captures", url.PathEscape(pID))
 	req, err := cs.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return

--- a/mollie/chargebacks.go
+++ b/mollie/chargebacks.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -60,7 +61,7 @@ type ChargebacksService service
 //
 // See: https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
 func (cs *ChargebacksService) Get(paymentID, chargebackID string, options *ChargebackOptions) (p Chargeback, err error) {
-	u := fmt.Sprintf("v2/payments/%s/chargebacks/%s", paymentID, chargebackID)
+	u := fmt.Sprintf("v2/payments/%s/chargebacks/%s", url.PathEscape(paymentID), url.PathEscape(chargebackID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())
@@ -95,7 +96,7 @@ func (cs *ChargebacksService) List(options *ListChargebackOptions) (cl *Chargeba
 //
 // See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
 func (cs *ChargebacksService) ListForPayment(paymentID string, options *ListChargebackOptions) (cl *ChargebackList, err error) {
-	u := fmt.Sprintf("v2/payments/%s/chargebacks", paymentID)
+	u := fmt.Sprintf("v2/payments/%s/chargebacks", url.PathEscape(paymentID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())

--- a/mollie/customers.go
+++ b/mollie/customers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -160,7 +161,7 @@ func (cs *CustomersService) List(options *ListCustomersOptions) (cl *CustomersLi
 //
 // See: https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
 func (cs *CustomersService) GetPayments(id string, options *ListCustomersOptions) (pl *PaymentList, err error) {
-	u := fmt.Sprintf("v2/customers/%s/payments", id)
+	u := fmt.Sprintf("v2/customers/%s/payments", url.PathEscape(id))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())
@@ -181,7 +182,7 @@ func (cs *CustomersService) GetPayments(id string, options *ListCustomersOptions
 //
 // See: https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
 func (cs *CustomersService) CreatePayment(id string, p Payment) (pp *Payment, err error) {
-	u := fmt.Sprintf("v2/customers/%s/payments", id)
+	u := fmt.Sprintf("v2/customers/%s/payments", url.PathEscape(id))
 	req, err := cs.client.NewAPIRequest(http.MethodPost, u, p)
 	if err != nil {
 		return

--- a/mollie/mandates.go
+++ b/mollie/mandates.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -101,7 +102,7 @@ type MandateList struct {
 //
 // See: https://docs.mollie.com/reference/v2/mandates-api/create-mandate
 func (ms *MandatesService) Create(cID string, mandate Mandate) (mr *Mandate, err error) {
-	u := fmt.Sprintf("v2/customers/%s/mandates", cID)
+	u := fmt.Sprintf("v2/customers/%s/mandates", url.PathEscape(cID))
 	req, err := ms.client.NewAPIRequest(http.MethodPost, u, mandate)
 	if err != nil {
 		return
@@ -125,7 +126,7 @@ func (ms *MandatesService) Create(cID string, mandate Mandate) (mr *Mandate, err
 //
 // See: https://docs.mollie.com/reference/v2/mandates-api/get-mandate
 func (ms *MandatesService) Get(cID, mID string) (mr *Mandate, err error) {
-	u := fmt.Sprintf("v2/customers/%s/mandates/%s", cID, mID)
+	u := fmt.Sprintf("v2/customers/%s/mandates/%s", url.PathEscape(cID), url.PathEscape(mID))
 	req, err := ms.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return
@@ -148,7 +149,7 @@ func (ms *MandatesService) Get(cID, mID string) (mr *Mandate, err error) {
 //
 // See: https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
 func (ms *MandatesService) Revoke(cID, mID string) (err error) {
-	u := fmt.Sprintf("v2/customers/%s/mandates/%s", cID, mID)
+	u := fmt.Sprintf("v2/customers/%s/mandates/%s", url.PathEscape(cID), url.PathEscape(mID))
 	req, err := ms.client.NewAPIRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return
@@ -167,7 +168,7 @@ func (ms *MandatesService) Revoke(cID, mID string) (err error) {
 //
 // See: https://docs.mollie.com/reference/v2/mandates-api/list-mandates
 func (ms *MandatesService) List(cID string, opt *ListMandatesOptions) (ml MandateList, err error) {
-	u := fmt.Sprintf("v2/customers/%s/mandates", cID)
+	u := fmt.Sprintf("v2/customers/%s/mandates", url.PathEscape(cID))
 	if opt != nil {
 		v, _ := query.Values(opt)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())

--- a/mollie/orders.go
+++ b/mollie/orders.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -345,7 +346,7 @@ func (ors *OrdersService) List(opt *OrderListOptions) (ordList *OrderList, err e
 //
 // See https://docs.mollie.com/reference/v2/orders-api/update-orderline
 func (ors *OrdersService) UpdateOrderLine(orderID string, orderLineID string, orderLine OrderLine) (order *Order, err error) {
-	u := fmt.Sprintf("v2/orders/%s/lines/%s", orderID, orderLineID)
+	u := fmt.Sprintf("v2/orders/%s/lines/%s", url.PathEscape(orderID), url.PathEscape(orderLineID))
 
 	req, err := ors.client.NewAPIRequest(http.MethodPatch, u, orderLine)
 	if err != nil {
@@ -370,7 +371,7 @@ func (ors *OrdersService) UpdateOrderLine(orderID string, orderLineID string, or
 //
 // See https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
 func (ors *OrdersService) CancelOrderLines(orderID string, orderLines []OrderLine) (err error) {
-	u := fmt.Sprintf("v2/orders/%s/lines", orderID)
+	u := fmt.Sprintf("v2/orders/%s/lines", url.PathEscape(orderID))
 
 	req, err := ors.client.NewAPIRequest(http.MethodDelete, u, orderLines)
 	if err != nil {
@@ -389,7 +390,7 @@ func (ors *OrdersService) CancelOrderLines(orderID string, orderLines []OrderLin
 // and when the status of the existing payment is either expired, canceled or failed.
 // See https://docs.mollie.com/reference/v2/orders-api/create-order-payment
 func (ors *OrdersService) CreateOrderPayment(orderID string, ordPay *OrderPayment) (payment *Payment, err error) {
-	u := fmt.Sprintf("v2/orders/%s/payments", orderID)
+	u := fmt.Sprintf("v2/orders/%s/payments", url.PathEscape(orderID))
 
 	req, err := ors.client.NewAPIRequest(http.MethodPost, u, ordPay)
 	if err != nil {
@@ -411,7 +412,7 @@ func (ors *OrdersService) CreateOrderPayment(orderID string, ordPay *OrderPaymen
 // CreateOrderRefund using the Orders API, refunds should be made against the order.
 // See https://docs.mollie.com/reference/v2/orders-api/create-order-refund
 func (ors *OrdersService) CreateOrderRefund(orderID string, order *Order) (refund Refund, err error) {
-	u := fmt.Sprintf("v2/orders/%s/refunds", orderID)
+	u := fmt.Sprintf("v2/orders/%s/refunds", url.PathEscape(orderID))
 
 	req, err := ors.client.NewAPIRequest(http.MethodPost, u, order)
 	if err != nil {
@@ -433,7 +434,7 @@ func (ors *OrdersService) CreateOrderRefund(orderID string, order *Order) (refun
 // ListOrderRefunds retrieve all order refunds.
 // See https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
 func (ors *OrdersService) ListOrderRefunds(orderID string, opt *OrderListRefundOptions) (orderListRefund OrderListRefund, err error) {
-	u := fmt.Sprintf("v2/orders/%s/refunds", orderID)
+	u := fmt.Sprintf("v2/orders/%s/refunds", url.PathEscape(orderID))
 	if opt != nil {
 		v, _ := query.Values(opt)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())

--- a/mollie/profiles.go
+++ b/mollie/profiles.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -167,7 +168,7 @@ func (ps *ProfilesService) Delete(id string) (err error) {
 // EnablePaymentMethod enables a payment method on a specific or authenticated profile.
 // If you're using API tokens for authentication, pass "me" as id.
 func (ps *ProfilesService) EnablePaymentMethod(id string, pm PaymentMethod) (pmi *PaymentMethodInfo, err error) {
-	u := fmt.Sprintf("v2/profiles/%s/methods/%s", id, pm)
+	u := fmt.Sprintf("v2/profiles/%s/methods/%s", url.PathEscape(id), pm)
 	req, err := ps.client.NewAPIRequest(http.MethodPost, u, nil)
 	if err != nil {
 		return
@@ -185,7 +186,7 @@ func (ps *ProfilesService) EnablePaymentMethod(id string, pm PaymentMethod) (pmi
 // DisablePaymentMethod disables a payment method on a specific or authenticated profile.
 // If you're using API tokens for authentication, pass "me" as id.
 func (ps *ProfilesService) DisablePaymentMethod(id string, pm PaymentMethod) (err error) {
-	u := fmt.Sprintf("v2/profiles/%s/methods/%s", id, pm)
+	u := fmt.Sprintf("v2/profiles/%s/methods/%s", url.PathEscape(id), pm)
 	req, err := ps.client.NewAPIRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return
@@ -254,7 +255,7 @@ func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(issuer GiftCardIssuer
 }
 
 func (ps *ProfilesService) toggleGiftCardIssuerStatus(profileID string, method string, issuer GiftCardIssuer) (r *Response, err error) {
-	u := fmt.Sprintf("v2/profiles/%s/methods/giftcard/issuers/%s", profileID, issuer)
+	u := fmt.Sprintf("v2/profiles/%s/methods/giftcard/issuers/%s", url.PathEscape(profileID), issuer)
 	req, err := ps.client.NewAPIRequest(method, u, nil)
 	if err != nil {
 		return

--- a/mollie/refunds.go
+++ b/mollie/refunds.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -82,7 +83,7 @@ type RefundsService service
 //
 // If you do not know the original payment’s ID, you can use the List payment refunds endpoint.
 func (rs *RefundsService) Get(paymentID, refundID string, options *RefundOptions) (refund Refund, err error) {
-	u := fmt.Sprintf("v2/payments/%s/refunds/%s", paymentID, refundID)
+	u := fmt.Sprintf("v2/payments/%s/refunds/%s", url.PathEscape(paymentID), url.PathEscape(refundID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())
@@ -109,7 +110,7 @@ func (rs *RefundsService) Get(paymentID, refundID string, options *RefundOptions
 //
 // See https://docs.mollie.com/reference/v2/refunds-api/create-refund.
 func (rs *RefundsService) Create(paymentID string, re Refund, options *RefundOptions) (rf Refund, err error) {
-	u := fmt.Sprintf("v2/payments/%s/refunds", paymentID)
+	u := fmt.Sprintf("v2/payments/%s/refunds", url.PathEscape(paymentID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())
@@ -140,7 +141,7 @@ func (rs *RefundsService) Create(paymentID string, re Refund, options *RefundOpt
 // The refund can only be canceled while the refund’s status is either queued or pending.
 // See https://docs.mollie.com/reference/v2/refunds-api/cancel-refund
 func (rs *RefundsService) Cancel(paymentID, refundID string, options *RefundOptions) (err error) {
-	u := fmt.Sprintf("v2/payments/%s/refunds/%s", paymentID, refundID)
+	u := fmt.Sprintf("v2/payments/%s/refunds/%s", url.PathEscape(paymentID), url.PathEscape(refundID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())
@@ -176,7 +177,7 @@ func (rs *RefundsService) ListRefund(options *ListRefundOptions) (rl *RefundList
 // Only refunds for that specific payment are returned.
 // See https://docs.mollie.com/reference/v2/refunds-api/list-refunds
 func (rs *RefundsService) ListRefundPayment(paymentID string, options *ListRefundOptions) (rl *RefundList, err error) {
-	u := fmt.Sprintf("v2/payments/%s/refunds", paymentID)
+	u := fmt.Sprintf("v2/payments/%s/refunds", url.PathEscape(paymentID))
 	if options != nil {
 		v, _ := query.Values(options)
 		u = fmt.Sprintf("%s?%s", u, v.Encode())

--- a/mollie/shipments.go
+++ b/mollie/shipments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -43,7 +44,7 @@ type ShipmentLinks struct {
 //
 // See: https://docs.mollie.com/reference/v2/shipments-api/get-shipment#
 func (ss *ShipmentsService) Get(oID string, sID string) (s *Shipment, err error) {
-	u := fmt.Sprintf("v2/orders/%s/shipments/%s", oID, sID)
+	u := fmt.Sprintf("v2/orders/%s/shipments/%s", url.PathEscape(oID), url.PathEscape(sID))
 	req, err := ss.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return
@@ -71,7 +72,7 @@ type CreateShipmentRequest struct {
 //
 // See: https://docs.mollie.com/reference/v2/shipments-api/create-shipment
 func (ss *ShipmentsService) Create(oID string, cs CreateShipmentRequest) (s *Shipment, err error) {
-	u := fmt.Sprintf("v2/orders/%s/shipments", oID)
+	u := fmt.Sprintf("v2/orders/%s/shipments", url.PathEscape(oID))
 
 	if ss.client.HasAccessToken() && ss.client.config.testing {
 		cs.TestMode = true
@@ -106,7 +107,7 @@ type ShipmentsList struct {
 //
 // See: https://docs.mollie.com/reference/v2/shipments-api/list-shipments
 func (ss *ShipmentsService) List(oID string) (sl *ShipmentsList, err error) {
-	u := fmt.Sprintf("v2/orders/%s/shipments", oID)
+	u := fmt.Sprintf("v2/orders/%s/shipments", url.PathEscape(oID))
 	req, err := ss.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return
@@ -127,7 +128,7 @@ func (ss *ShipmentsService) List(oID string) (sl *ShipmentsList, err error) {
 //
 // See: https://docs.mollie.com/reference/v2/shipments-api/update-shipment
 func (ss *ShipmentsService) Update(oID string, sID string, st ShipmentTracking) (s *Shipment, err error) {
-	u := fmt.Sprintf("v2/orders/%s/shipments/%s", oID, sID)
+	u := fmt.Sprintf("v2/orders/%s/shipments/%s", url.PathEscape(oID), url.PathEscape(sID))
 	req, err := ss.client.NewAPIRequest(http.MethodPatch, u, st)
 	if err != nil {
 		return

--- a/mollie/subscriptions.go
+++ b/mollie/subscriptions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -76,7 +77,7 @@ type SubscriptionListOptions struct {
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
 func (ss *SubscriptionsService) Get(cID, sID string) (s *Subscription, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", cID, sID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", url.PathEscape(cID), url.PathEscape(sID))
 	req, err := ss.client.NewAPIRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return
@@ -97,7 +98,7 @@ func (ss *SubscriptionsService) Get(cID, sID string) (s *Subscription, err error
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
 func (ss *SubscriptionsService) Create(cID string, sc *Subscription) (s *Subscription, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions", cID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions", url.PathEscape(cID))
 
 	if ss.client.HasAccessToken() && ss.client.config.testing {
 		sc.TestMode = true
@@ -123,7 +124,7 @@ func (ss *SubscriptionsService) Create(cID string, sc *Subscription) (s *Subscri
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
 func (ss *SubscriptionsService) Update(cID, sID string, sc *Subscription) (s *Subscription, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", cID, sID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", url.PathEscape(cID), url.PathEscape(sID))
 
 	req, err := ss.client.NewAPIRequest(http.MethodPatch, u, sc)
 	if err != nil {
@@ -145,7 +146,7 @@ func (ss *SubscriptionsService) Update(cID, sID string, sc *Subscription) (s *Su
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
 func (ss *SubscriptionsService) Delete(cID, sID string) (s *Subscription, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", cID, sID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s", url.PathEscape(cID), url.PathEscape(sID))
 	req, err := ss.client.NewAPIRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return
@@ -190,7 +191,7 @@ func (ss *SubscriptionsService) All(options *SubscriptionListOptions) (sl *Subsc
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
 func (ss *SubscriptionsService) List(cID string, options *SubscriptionListOptions) (sl *SubscriptionList, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions", cID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions", url.PathEscape(cID))
 
 	if options != nil {
 		v, _ := query.Values(options)
@@ -212,7 +213,7 @@ func (ss *SubscriptionsService) List(cID string, options *SubscriptionListOption
 //
 // See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
 func (ss *SubscriptionsService) GetPayments(cID, sID string, options *SubscriptionListOptions) (sl *PaymentList, err error) {
-	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s/payments", cID, sID)
+	u := fmt.Sprintf("v2/customers/%s/subscriptions/%s/payments", url.PathEscape(cID), url.PathEscape(sID))
 
 	if options != nil {
 		v, _ := query.Values(options)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Issue #150 lists multiple places where unescaped variable are used in constructed URLs. I have gone through them all and added `net/url`'s `PathEscape` to each.

## Motivation and context

Passed variables may contain unsafe characters for a request. As such, some users resort to escaping their own variables, requiring knowledge of--and leaking information about--an implementation detail that could conceivably change.

Fixes #150

## How has this been tested?

This change has not been tested at all at this point. I'm posting the draft PR now because I have questions about other variables, and the implications of the change.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

# Questions from me

1. Should this change require/include some sort of version bump in order to prevent double escaping by users who are currently performing their own escaping?
2. Should some documentation be added to types like `PaymentMethod` that are essentially strings that may be used in constructed URLs so that any future updates to those types will be URL safe? I realize it is unlikely that a payment type will have unsafe characters in, but it's just an example.
