### PR TITLE
Add Metadata field to OrderLine

### DIFF
--- a/mollie/orders.go
+++ b/mollie/orders.go
@@ -134,6 +134,7 @@ type OrderLine struct {
 	Links              OrderLineLinks  `json:"_links,omitempty"`
 	ImageURL           string          `json:"imageUrl,omitempty"`
 	ProductURL         string          `json:"productUrl,omitempty"`
+	Metadata           interface{}     `json:"metadata,omitempty"`
 }
 
 // OrderList for containing the response of list orders


### PR DESCRIPTION
## Description

The metadata parameter was still missing in the OrderLine struct, this has now been solved by adding the field 'Metadata'.

## Motivation and context

This change fixes #161.

## How has this been tested?

I have tested the code with this modification and it worked.
It is exactly the same as the Metadata field in the Order struct, so I would expect it to behave no different.
I have not added any new tests, as I think this change does not require any changes to the current tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
