### PR TITLE
Fix metadata type

### DIFF
--- a/mollie/customers.go
+++ b/mollie/customers.go
@@ -22,15 +22,15 @@ type CustomerLinks struct {
 
 // Customer represents buyers.
 type Customer struct {
-	Resource  string                 `json:"resource,omitempty"`
-	ID        string                 `json:"id,omitempty"`
-	Mode      Mode                   `json:"mode,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Email     string                 `json:"email,omitempty"`
-	Locale    Locale                 `json:"locale,omitempty"`
-	Metadata  map[string]interface{} `json:"metadata,omitempty"`
-	CreatedAt *time.Time             `json:"createdAt,omitempty"`
-	Links     CustomerLinks          `json:"_links,omitempty"`
+	Resource  string        `json:"resource,omitempty"`
+	ID        string        `json:"id,omitempty"`
+	Mode      Mode          `json:"mode,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	Email     string        `json:"email,omitempty"`
+	Locale    Locale        `json:"locale,omitempty"`
+	Metadata  interface{}   `json:"metadata,omitempty"`
+	CreatedAt *time.Time    `json:"createdAt,omitempty"`
+	Links     CustomerLinks `json:"_links,omitempty"`
 }
 
 // CustomersListOptions contains valid query parameters for the list customers endpoint.

--- a/mollie/subscriptions.go
+++ b/mollie/subscriptions.go
@@ -32,26 +32,26 @@ type SubscriptionLinks struct {
 
 // Subscription contains information about a customer subscription.
 type Subscription struct {
-	Resource        string                 `json:"resource,omitempty"`
-	ID              string                 `json:"id,omitempty"`
-	MandateID       string                 `json:"mandateId,omitempty"`
-	Mode            Mode                   `json:"mode,omitempty"`
-	CreatedAT       *time.Time             `json:"createdAt,omitempty"`
-	Status          SubscriptionStatus     `json:"status,omitempty"`
-	Amount          *Amount                `json:"amount,omitempty"`
-	Times           int                    `json:"times,omitempty"`
-	TimesRemaining  int                    `json:"timesRemaining,omitempty"`
-	Interval        string                 `json:"interval,omitempty"`
-	StartDate       *ShortDate             `json:"startDate,omitempty"`
-	NextPaymentDate *ShortDate             `json:"nextPaymentDate,omitempty"`
-	Description     string                 `json:"description,omitempty"`
-	Method          PaymentMethod          `json:"method,omitempty"`
-	CanceledAt      *time.Time             `json:"canceledAt,omitempty"`
-	WebhookURL      string                 `json:"webhookUrl,omitempty"`
-	Metadata        map[string]interface{} `json:"metadata,omitempty"`
-	ApplicationFee  *ApplicationFee        `json:"applicationFee,omitempty"`
-	TestMode        bool                   `json:"testmode,omitempty"`
-	Links           SubscriptionLinks      `json:"_links,omitempty"`
+	Resource        string             `json:"resource,omitempty"`
+	ID              string             `json:"id,omitempty"`
+	MandateID       string             `json:"mandateId,omitempty"`
+	Mode            Mode               `json:"mode,omitempty"`
+	CreatedAT       *time.Time         `json:"createdAt,omitempty"`
+	Status          SubscriptionStatus `json:"status,omitempty"`
+	Amount          *Amount            `json:"amount,omitempty"`
+	Times           int                `json:"times,omitempty"`
+	TimesRemaining  int                `json:"timesRemaining,omitempty"`
+	Interval        string             `json:"interval,omitempty"`
+	StartDate       *ShortDate         `json:"startDate,omitempty"`
+	NextPaymentDate *ShortDate         `json:"nextPaymentDate,omitempty"`
+	Description     string             `json:"description,omitempty"`
+	Method          PaymentMethod      `json:"method,omitempty"`
+	CanceledAt      *time.Time         `json:"canceledAt,omitempty"`
+	WebhookURL      string             `json:"webhookUrl,omitempty"`
+	Metadata        interface{}        `json:"metadata,omitempty"`
+	ApplicationFee  *ApplicationFee    `json:"applicationFee,omitempty"`
+	TestMode        bool               `json:"testmode,omitempty"`
+	Links           SubscriptionLinks  `json:"_links,omitempty"`
 }
 
 // SubscriptionList describes the response for subscription list endpoints.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the `Metadata` field for creating customers and subscriptions from `map[string]interface{}` to `interface{}` which is the correct type according to the docs (https://docs.mollie.com/reference/v2/customers-api/create-customer https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription) and is also used elsewhere in this library.

## Motivation and context

I want to use a string as metadata which is currently not possible.

## How has this been tested?

Not needed, but tested in local deployment and unit tests are passing.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
