### PR TITLE
fix issue with testmode query parameter

### DIFF
--- a/mollie/miscellaneous_test.go
+++ b/mollie/miscellaneous_test.go
@@ -44,7 +44,6 @@ func (ms *miscellaneousServiceSuite) TestMiscellaneousService_ApplePaymentSessio
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "POST")
-				testQuery(ms.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/mollie.go
+++ b/mollie/mollie.go
@@ -161,7 +161,7 @@ func (c *Client) NewAPIRequest(ctx context.Context, method string, uri string, b
 		return nil, fmt.Errorf("url_parsing_error: %w", err)
 	}
 
-	if c.config.testing {
+	if c.config.testing && c.HasAccessToken() {
 		qp := url.Query()
 		qp.Add("testmode", "true")
 		url.RawQuery = qp.Encode()

--- a/mollie/mollie_test.go
+++ b/mollie/mollie_test.go
@@ -50,7 +50,9 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientWithEnvVars(t *testing.T) {
 	setEnv()
+	setup()
 	defer unsetEnv()
+	defer teardown()
 
 	var c = http.DefaultClient
 	{
@@ -106,7 +108,7 @@ func TestClient_NewAPIRequest(t *testing.T) {
 				body:   []string{"hello", "world"},
 			},
 			`["hello","world"]` + "\n",
-			"/test?testmode=true",
+			"/test",
 			false,
 		},
 		{
@@ -118,7 +120,7 @@ func TestClient_NewAPIRequest(t *testing.T) {
 				body:   "some simple string",
 			},
 			"\"some simple string\"\n",
-			"/test?testmode=true",
+			"/test",
 			true,
 		},
 	}
@@ -458,7 +460,7 @@ func teardown() {
 
 func setEnv() {
 	_ = os.Setenv(APITokenEnv, "token_X12b31ggg23")
-	_ = os.Setenv(OrgTokenEnv, "ey1923n23123n1k3b123jv12g312h31v32g13")
+	_ = os.Setenv(OrgTokenEnv, "access_ey1923n23123n1k3b123jv12g312h31v32g13")
 }
 
 func unsetEnv() {

--- a/mollie/onboarding_test.go
+++ b/mollie/onboarding_test.go
@@ -32,7 +32,6 @@ func (os *onboardingServiceSuite) TestOnboardingService_GetOnboardingStatus() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -102,7 +101,6 @@ func (os *onboardingServiceSuite) TestOnboardingService_SubmitOnboardingData() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/orders_test.go
+++ b/mollie/orders_test.go
@@ -45,7 +45,7 @@ func (os *ordersServiceSuite) TestOrdersService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "profileId=pfl_1236h213bv1&testmode=true")
+				testQuery(os.T(), r, "profileId=pfl_1236h213bv1")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -141,7 +141,7 @@ func (os *ordersServiceSuite) TestOrdersService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "profileId=pfl_1236h213bv1&testmode=true")
+				testQuery(os.T(), r, "profileId=pfl_1236h213bv1")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -237,7 +237,6 @@ func (os *ordersServiceSuite) TestOrdersService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -262,7 +261,6 @@ func (os *ordersServiceSuite) TestOrdersService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -365,7 +363,6 @@ func (os *ordersServiceSuite) TestOrdersService_Update() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "PATCH")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -390,7 +387,6 @@ func (os *ordersServiceSuite) TestOrdersService_Update() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "PATCH")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -493,7 +489,6 @@ func (os *ordersServiceSuite) TestOrdersService_Cancel() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "DELETE")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -518,7 +513,6 @@ func (os *ordersServiceSuite) TestOrdersService_Cancel() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "DELETE")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -621,7 +615,6 @@ func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "PATCH")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -647,7 +640,6 @@ func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "PATCH")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -753,7 +745,6 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "DELETE")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -779,7 +770,6 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "DELETE")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -873,7 +863,6 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -899,7 +888,6 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -991,7 +979,6 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1013,7 +1000,6 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "POST")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1104,7 +1090,7 @@ func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "limit=100&testmode=true")
+				testQuery(os.T(), r, "limit=100")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1127,7 +1113,6 @@ func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/organizations_test.go
+++ b/mollie/organizations_test.go
@@ -42,7 +42,6 @@ func (os *organizationsServiceSuite) TestOrganizationsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -130,7 +129,6 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetCurrent() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -215,7 +213,6 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetPartnerStatus()
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/partners_test.go
+++ b/mollie/partners_test.go
@@ -44,7 +44,6 @@ func (os *partnersServiceSuite) TestPartnerService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -67,7 +66,7 @@ func (os *partnersServiceSuite) TestPartnerService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "embed=organization&testmode=true")
+				testQuery(os.T(), r, "embed=organization")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -162,7 +161,6 @@ func (os *partnersServiceSuite) TestPartnerService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -185,7 +183,7 @@ func (os *partnersServiceSuite) TestPartnerService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "testmode=true&year=2021")
+				testQuery(os.T(), r, "year=2021")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/payment_links_test.go
+++ b/mollie/payment_links_test.go
@@ -44,7 +44,6 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -141,7 +140,7 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "profileId=prf_12312312&testmode=true")
+				testQuery(ps.T(), r, "profileId=prf_12312312")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -234,7 +233,6 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -256,7 +254,7 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "profileId=pfl_11211&testmode=true")
+				testQuery(ps.T(), r, "profileId=pfl_11211")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/payment_methods_test.go
+++ b/mollie/payment_methods_test.go
@@ -42,7 +42,6 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -65,7 +64,7 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00&testmode=true")
+				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -155,7 +154,6 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -178,7 +176,7 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00&testmode=true")
+				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -270,7 +268,6 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -291,7 +288,7 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "locale=ca_ES&testmode=true")
+				testQuery(ms.T(), r, "locale=ca_ES")
 
 				fmt.Println(r.Context())
 

--- a/mollie/payments_test.go
+++ b/mollie/payments_test.go
@@ -45,7 +45,7 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "include=settlements&testmode=true")
+				testQuery(ps.T(), r, "include=settlements")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -139,7 +139,7 @@ func (ps *paymentsServiceSuite) TestPaymentsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "from=tr_12o93213&testmode=true")
+				testQuery(ps.T(), r, "from=tr_12o93213")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -230,13 +230,11 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
 			},
 			false,
 			nil,
-			func() {
-				tClient.WithAuthenticationValue("access_example_token")
-			},
+			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_example_token")
+				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "include=settlements&testmode=true")
+				testQuery(ps.T(), r, "include=settlements")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -257,9 +255,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
 			},
 			false,
 			nil,
-			noPre,
+			setAccesstoken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(ps.T(), r, "POST")
 				testQuery(ps.T(), r, "include=settlements&testmode=true")
 
@@ -357,7 +355,6 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Update() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -474,7 +471,6 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Cancel() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/permissions_test.go
+++ b/mollie/permissions_test.go
@@ -16,9 +16,7 @@ func (os *permissionsServiceSuite) SetupSuite() { setEnv() }
 
 func (os *permissionsServiceSuite) TearDownSuite() { unsetEnv() }
 
-func (os *permissionsServiceSuite) TestPermissionsService_Get() { unsetEnv() }
-
-func (ps *profilesServiceSuite) TestPermissionsService_Get() {
+func (ps *permissionsServiceSuite) TestPermissionsService_Get() {
 	type args struct {
 		ctx        context.Context
 		permission PermissionGrant
@@ -39,9 +37,11 @@ func (ps *profilesServiceSuite) TestPermissionsService_Get() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -130,7 +130,6 @@ func (ps *permissionsServiceSuite) TestPermissionsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/profiles_test.go
+++ b/mollie/profiles_test.go
@@ -37,9 +37,11 @@ func (ps *profilesServiceSuite) TestProfilesService_Get() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -117,9 +119,11 @@ func (ps *profilesServiceSuite) TestProfilesService_GetCurrent() {
 			"get current profile works as expected.",
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -194,9 +198,11 @@ func (ps *profilesServiceSuite) TestProfilesService_List() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -216,9 +222,11 @@ func (ps *profilesServiceSuite) TestProfilesService_List() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
 				testQuery(ps.T(), r, "limit=100&testmode=true")
 
@@ -307,9 +315,11 @@ func (ps *profilesServiceSuite) TestProfilesService_Create() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -400,9 +410,11 @@ func (ps *profilesServiceSuite) TestProfilesService_Update() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "PATCH")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -492,9 +504,11 @@ func (ps *profilesServiceSuite) TestProfilesService_Delete() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -571,9 +585,11 @@ func (ps *profilesServiceSuite) TestProfilesService_EnablePaymentMethod() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -665,9 +681,11 @@ func (ps *profilesServiceSuite) TestProfilesService_DisablePaymentMethod() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -747,9 +765,11 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuer() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -841,9 +861,11 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuer() {
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -921,9 +943,11 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuerForCurre
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
 				testQuery(ps.T(), r, "testmode=true")
 
@@ -1010,9 +1034,11 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuerForCurr
 			},
 			false,
 			nil,
-			noPre,
+			func() {
+				tClient.WithAuthenticationValue("access_X12b31ggg23")
+			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
+				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
 				testQuery(ps.T(), r, "testmode=true")
 

--- a/mollie/refunds_test.go
+++ b/mollie/refunds_test.go
@@ -47,7 +47,7 @@ func (rs *refundsServiceTest) TestRefundsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "embed=profile&testmode=true")
+				testQuery(rs.T(), r, "embed=profile")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -153,7 +153,7 @@ func (rs *refundsServiceTest) TestRefundsService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(rs.T(), r, "POST")
-				testQuery(rs.T(), r, "embed=profile&testmode=true")
+				testQuery(rs.T(), r, "embed=profile")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -292,7 +292,6 @@ func (rs *refundsServiceTest) TestRefundsService_Cancel() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(rs.T(), r, "DELETE")
-				testQuery(rs.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -375,7 +374,7 @@ func (rs *refundsServiceTest) TestRefundsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "limit=10&testmode=true")
+				testQuery(rs.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -473,7 +472,7 @@ func (rs *refundsServiceTest) TestRefundsService_ListPaynents() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "limit=10&testmode=true")
+				testQuery(rs.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/settlements_test.go
+++ b/mollie/settlements_test.go
@@ -41,7 +41,6 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -130,7 +129,6 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Next() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -219,7 +217,6 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Open() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -310,7 +307,7 @@ func (ps *settlementsServiceSuite) TestSettlementsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=40&testmode=true")
+				testQuery(ps.T(), r, "limit=40")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -409,7 +406,7 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetPayments() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -511,7 +508,7 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetCaptures() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -613,7 +610,7 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetChargebacks() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -715,7 +712,7 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetRefunds() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)

--- a/mollie/shipments_test.go
+++ b/mollie/shipments_test.go
@@ -43,7 +43,6 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -137,7 +136,6 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -233,7 +231,6 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -252,9 +249,7 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
 			},
 			false,
 			nil,
-			func() {
-				tClient.WithAuthenticationValue("access_token_test")
-			},
+			setAccesstoken,
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(ps.T(), r, "POST")
@@ -362,7 +357,6 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -382,9 +376,7 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
 			},
 			false,
 			nil,
-			func() {
-				tClient.WithAuthenticationValue("access_token_test")
-			},
+			setAccesstoken,
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
 				testMethod(ps.T(), r, "PATCH")

--- a/mollie/subscriptions_test.go
+++ b/mollie/subscriptions_test.go
@@ -43,7 +43,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Get() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -143,7 +142,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Create() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -290,7 +288,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Update() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -433,7 +430,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Delete() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -548,7 +544,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -571,7 +566,7 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -663,7 +658,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -685,7 +679,7 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -778,7 +772,6 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -802,7 +795,7 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
 			func(w http.ResponseWriter, r *http.Request) {
 				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
 				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10&testmode=true")
+				testQuery(ps.T(), r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mollie requires only the `testmode=true` query parameter for test requests when using access tokens.

## Motivation and context

Closes #188 

## How has this been tested?

- Manual testing
- Test suites updated

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
