### PR TITLE
Update common_types.go

### DIFF
--- a/mollie/common_types.go
+++ b/mollie/common_types.go
@@ -156,8 +156,8 @@ type EmbedValue string
 
 // Valid Embed query string value.
 const (
-	EmbedPayment     EmbedValue = "payment"
-	EmbedRefund      EmbedValue = "refund"
+	EmbedPayment     EmbedValue = "payments"
+	EmbedRefund      EmbedValue = "refunds"
 	EmbedShipments   EmbedValue = "shipments"
 	EmbedChangebacks EmbedValue = "chanrgebacks"
 )


### PR DESCRIPTION
Hello Victor.
Embed query string values for the get order request must be in plural form according to the docs. Please consider updating constants values.
Documentation link: https://docs.mollie.com/reference/v2/orders-api/get-order