### PR TITLE
mark order shipping address optional

### DIFF
--- a/mollie/orders.go
+++ b/mollie/orders.go
@@ -26,7 +26,7 @@ type Order struct {
 	Method                                   PaymentMethod `json:"method,omitempty"`
 	Status                                   OrderStatus   `json:"status,omitempty"`
 	Locale                                   Locale        `json:"locale,omitempty"`
-	ShippingAddress                          OrderAddress  `json:"shippingAddress,omitempty"`
+	ShippingAddress                          *OrderAddress `json:"shippingAddress,omitempty"`
 	Links                                    OrderLinks    `json:"_links,omitempty"`
 	Amount                                   *Amount       `json:"amount,omitempty"`
 	AmountCaptured                           *Amount       `json:"amountCaptured,omitempty"`
@@ -257,7 +257,7 @@ type OrderListRefundOptions struct {
 	Embed EmbedValue `url:"embed,omitempty"`
 }
 
-// OrdersService instance operates over refund resources.
+// OrdersService instance operates over order resources.
 type OrdersService service
 
 // Get retrieve a single order by its ID.

--- a/mollie/orders_test.go
+++ b/mollie/orders_test.go
@@ -54,6 +54,22 @@ func (os *ordersServiceSuite) TestOrdersService_Get() {
 			},
 		},
 		{
+			"get orders without shipping address works as expected.",
+			args{
+				context.Background(),
+				"ord_kEn1PlbGa",
+				&OrderOptions{
+					ProfileID: "pfl_1236h213bv1",
+				},
+			},
+			false,
+			nil,
+			noPre,
+			func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(testdata.GetOrderWithoutShippingResponse))
+			},
+		},
+		{
 			"get orders, an error is returned from the server",
 			args{
 				context.Background(),

--- a/testdata/orders.go
+++ b/testdata/orders.go
@@ -287,6 +287,117 @@ const GetOrderResponse = `{
      }
  }`
 
+const GetOrderWithoutShippingResponse = `{
+     "resource": "order",
+     "id": "ord_kEn1PlbGa",
+     "profileId": "pfl_URR55HPMGx",
+     "method": "ideal",
+     "amount": {
+         "value": "1027.99",
+         "currency": "EUR"
+     },
+     "status": "created",
+     "isCancelable": true,
+     "metadata": null,
+     "createdAt": "2018-08-02T09:29:56+00:00",
+     "expiresAt": "2018-08-30T09:29:56+00:00",
+     "mode": "live",
+     "locale": "nl_NL",
+     "billingAddress": {
+         "organizationName": "Mollie B.V.",
+         "streetAndNumber": "Keizersgracht 313",
+         "postalCode": "1016 EE",
+         "city": "Amsterdam",
+         "country": "nl",
+         "givenName": "Luke",
+         "familyName": "Skywalker",
+         "email": "luke@skywalker.com"
+     },
+     "shopperCountryMustMatchBillingCountry": false,
+     "consumerDateOfBirth": "1993-10-21",
+     "orderNumber": "18475",
+     "redirectUrl": "https://example.org/redirect",
+     "lines": [
+         {
+             "resource": "orderline",
+             "id": "odl_dgtxyl",
+             "orderId": "ord_pbjz8x",
+             "name": "LEGO Digital 42083 Bugatti Chiron",
+             "sku": "5702016116977",
+             "type": "digital",
+             "status": "created",
+             "metadata": null,
+             "isCancelable": false,
+             "quantity": 2,
+             "quantityShipped": 0,
+             "amountShipped": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityRefunded": 0,
+             "amountRefunded": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "quantityCanceled": 0,
+             "amountCanceled": {
+                 "value": "0.00",
+                 "currency": "EUR"
+             },
+             "shippableQuantity": 0,
+             "refundableQuantity": 0,
+             "cancelableQuantity": 0,
+             "unitPrice": {
+                 "value": "399.00",
+                 "currency": "EUR"
+             },
+             "vatRate": "21.00",
+             "vatAmount": {
+                 "value": "121.14",
+                 "currency": "EUR"
+             },
+             "discountAmount": {
+                 "value": "100.00",
+                 "currency": "EUR"
+             },
+             "totalAmount": {
+                 "value": "698.00",
+                 "currency": "EUR"
+             },
+             "createdAt": "2018-08-02T09:29:56+00:00",
+             "_links": {
+                 "productUrl": {
+                     "href": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+                     "type": "text/html"
+                 },
+                 "imageUrl": {
+                     "href": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+                     "type": "text/html"
+                 }
+             }
+         }
+     ],
+     "_embedded": {},
+     "_links": {
+         "self": {
+             "href": "https://api.mollie.com/v2/orders/ord_pbjz8x",
+             "type": "application/hal+json"
+         },
+         "checkout": {
+             "href": "https://www.mollie.com/payscreen/order/checkout/pbjz8x",
+             "type": "text/html"
+         },
+        "dashboard": {
+            "href": "https://www.mollie.com/dashboard/org_123456789/orders/ord_pbjz8x",
+            "type": "text/html"
+        },
+         "documentation": {
+             "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+             "type": "text/html"
+         }
+     }
+ }`
+
 // CreateOrderRequest example of create order request
 const CreateOrderRequest = `{
 	"amount": {


### PR DESCRIPTION
# Description

Hi there, 

It's been a long time coming (#271 ) but this PR changes the shipping address from value to pointer, allowing empty values to be skipped during serialisation. 

I'm running my fork of the lib in the wild and it seems to work. Since it's been a while since I've contributed to a go lib repo I'm a bit skeptic that this is good enough to merge. 

- [ ] What do you think about the test, feels a bit misplaced tbh
- [ ] Changing the method signature breaks the API design, so it's backwards incompatible with v3 right?
- [ ] Running tests on go 1.20 breaks, is that just me?

Let me know what you think ;) 

## Motivation and context

When selling digital goods there is no need to send a shipping address when creating an order. The API docs even dictate that this address is optional. I merely made the field optional in the api client library. 

See #271 for our initial discussion.

## How has this been tested?

Did a test order on my local app running a mollie integration in test-mode. 
You can see that the order no longer has the address attached to it. Here's a before and after:
![Screenshot 2023-11-26 at 13 15 17](https://github.com/VictorAvelar/mollie-api-go/assets/3368018/22cb90c8-9e0f-4ed7-8823-0ba11972b814)

![Screenshot 2023-11-26 at 13 15 30](https://github.com/VictorAvelar/mollie-api-go/assets/3368018/4cf9d5fa-4aee-4974-b6f2-ecefcac4319c)

- [x] Unit tests added / updated
- [ ] The tests run on docker (using `make test`)
- [x] The required `test data` has been added / updated

If you are running the tests locally, please specify:

- OS: macos
- Go version 1.21

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
