### PR TITLE
remove testify testing suites

### DIFF
--- a/mollie/balances_test.go
+++ b/mollie/balances_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type balancesServiceSuite struct{ suite.Suite }
+func TestBalancesService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (bs *balancesServiceSuite) SetupSuite() { setEnv() }
-
-func (bs *balancesServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (bs *balancesServiceSuite) TestBalancesService_Get() {
 	type args struct {
 		ctx     context.Context
 		balance string
@@ -39,8 +36,8 @@ func (bs *balancesServiceSuite) TestBalancesService_Get() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -88,7 +85,7 @@ func (bs *balancesServiceSuite) TestBalancesService_Get() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -101,19 +98,22 @@ func (bs *balancesServiceSuite) TestBalancesService_Get() {
 
 			res, capture, err := tClient.Balances.Get(c.args.ctx, c.args.balance)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&Balance{}, capture)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Balance{}, capture)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_Primary() {
+func TestBalancesService_Primary(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 	}
@@ -134,8 +134,8 @@ func (bs *balancesServiceSuite) TestBalancesService_Primary() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -180,7 +180,7 @@ func (bs *balancesServiceSuite) TestBalancesService_Primary() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -190,19 +190,22 @@ func (bs *balancesServiceSuite) TestBalancesService_Primary() {
 
 			res, capture, err := tClient.Balances.Primary(c.args.ctx)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&Balance{}, capture)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Balance{}, capture)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_List() {
+func TestBalancesService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *BalanceListOptions
@@ -225,8 +228,8 @@ func (bs *balancesServiceSuite) TestBalancesService_List() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -274,7 +277,7 @@ func (bs *balancesServiceSuite) TestBalancesService_List() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -284,19 +287,22 @@ func (bs *balancesServiceSuite) TestBalancesService_List() {
 
 			res, capture, err := tClient.Balances.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&BalancesList{}, capture)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &BalancesList{}, capture)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_GetReport() {
+func TestBalancesService_GetReport(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		balance string
@@ -321,8 +327,8 @@ func (bs *balancesServiceSuite) TestBalancesService_GetReport() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -373,7 +379,7 @@ func (bs *balancesServiceSuite) TestBalancesService_GetReport() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -386,20 +392,22 @@ func (bs *balancesServiceSuite) TestBalancesService_GetReport() {
 
 			res, balanceReport, err := tClient.Balances.GetReport(c.args.ctx, c.args.balance, c.args.options)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&BalanceReport{}, balanceReport)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
-				fmt.Printf("\n%+v\n", *balanceReport)
+				assert.Nil(t, err)
+				assert.IsType(t, &BalanceReport{}, balanceReport)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_GetPrimaryReport() {
+func TestBalancesService_GetPrimaryReport(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *BalanceReportOptions
@@ -423,8 +431,8 @@ func (bs *balancesServiceSuite) TestBalancesService_GetPrimaryReport() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -475,7 +483,7 @@ func (bs *balancesServiceSuite) TestBalancesService_GetPrimaryReport() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -488,19 +496,22 @@ func (bs *balancesServiceSuite) TestBalancesService_GetPrimaryReport() {
 
 			res, balanceReport, err := tClient.Balances.GetPrimaryReport(c.args.ctx, c.args.options)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&BalanceReport{}, balanceReport)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &BalanceReport{}, balanceReport)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_ListBalanceTransactions() {
+func TestBalancesService_ListBalanceTransactions(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		balance string
@@ -525,8 +536,8 @@ func (bs *balancesServiceSuite) TestBalancesService_ListBalanceTransactions() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -577,7 +588,7 @@ func (bs *balancesServiceSuite) TestBalancesService_ListBalanceTransactions() {
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -590,19 +601,22 @@ func (bs *balancesServiceSuite) TestBalancesService_ListBalanceTransactions() {
 
 			res, balanceReport, err := tClient.Balances.GetTransactionsList(c.args.ctx, c.args.balance, c.args.options)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&BalanceTransactionsList{}, balanceReport)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &BalanceTransactionsList{}, balanceReport)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (bs *balancesServiceSuite) TestBalancesService_ListPrimaryBalanceTransactions() {
+func TestBalancesService_ListPrimaryBalanceTransactions(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *BalanceTransactionsListOptions
@@ -625,8 +639,8 @@ func (bs *balancesServiceSuite) TestBalancesService_ListPrimaryBalanceTransactio
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(bs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(bs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -674,7 +688,7 @@ func (bs *balancesServiceSuite) TestBalancesService_ListPrimaryBalanceTransactio
 		setup()
 		defer teardown()
 
-		bs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -687,18 +701,14 @@ func (bs *balancesServiceSuite) TestBalancesService_ListPrimaryBalanceTransactio
 
 			res, balanceReport, err := tClient.Balances.GetPrimaryTransactionsList(c.args.ctx, c.args.options)
 			if c.wantErr {
-				bs.NotNil(err)
-				bs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				bs.Nil(err)
-				bs.IsType(&BalanceTransactionsList{}, balanceReport)
-				bs.Same(c.args.ctx, res.Request.Context())
-				bs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &BalanceTransactionsList{}, balanceReport)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestBalancesService(t *testing.T) {
-	suite.Run(t, new(balancesServiceSuite))
 }

--- a/mollie/captures_test.go
+++ b/mollie/captures_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type capturesServiceSuite struct{ suite.Suite }
+func TestCapturesService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (cs *capturesServiceSuite) SetupSuite() { setEnv() }
-
-func (cs *capturesServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (cs *capturesServiceSuite) TestCapturesService_Get() {
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -41,8 +38,8 @@ func (cs *capturesServiceSuite) TestCapturesService_Get() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -93,7 +90,7 @@ func (cs *capturesServiceSuite) TestCapturesService_Get() {
 		setup()
 		defer teardown()
 
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -107,19 +104,22 @@ func (cs *capturesServiceSuite) TestCapturesService_Get() {
 
 			res, capture, err := tClient.Captures.Get(c.args.ctx, c.args.payment, c.args.capture)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&Capture{}, capture)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Capture{}, capture)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *capturesServiceSuite) TestCapturesService_List() {
+func TestCapturesService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -146,8 +146,8 @@ func (cs *capturesServiceSuite) TestCapturesService_List() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -198,7 +198,7 @@ func (cs *capturesServiceSuite) TestCapturesService_List() {
 		setup()
 		defer teardown()
 
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 
 			tMux.HandleFunc(
@@ -211,18 +211,14 @@ func (cs *capturesServiceSuite) TestCapturesService_List() {
 
 			res, list, err := tClient.Captures.List(c.args.ctx, c.args.payment)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&CapturesList{}, list)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &CapturesList{}, list)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestCapturesService(t *testing.T) {
-	suite.Run(t, new(capturesServiceSuite))
 }

--- a/mollie/chargebacks_test.go
+++ b/mollie/chargebacks_test.go
@@ -8,16 +8,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type chargebacksSuite struct{ suite.Suite }
+func TestChargebacksService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (cbs *chargebacksSuite) SetupSuite() { setEnv() }
-
-func (cbs *chargebacksSuite) TearDownSuite() { unsetEnv() }
-
-func (cbs *chargebacksSuite) TestChargebacksService_Get() {
 	type args struct {
 		ctx        context.Context
 		payment    string
@@ -46,8 +43,8 @@ func (cbs *chargebacksSuite) TestChargebacksService_Get() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cbs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cbs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -109,7 +106,7 @@ func (cbs *chargebacksSuite) TestChargebacksService_Get() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		cbs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			tMux.HandleFunc(
 				fmt.Sprintf(
 					"/v2/payments/%s/chargebacks/%s",
@@ -122,19 +119,22 @@ func (cbs *chargebacksSuite) TestChargebacksService_Get() {
 
 			res, cb, err := tClient.Chargebacks.Get(c.args.ctx, c.args.payment, c.args.chargeback, c.args.options)
 			if c.wantErr {
-				cbs.Error(err)
-				cbs.EqualError(err, c.err.Error())
+				assert.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cbs.Nil(err)
-				cbs.Same(c.args.ctx, res.Request.Context())
-				cbs.IsType(&Chargeback{}, cb)
-				cbs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &Chargeback{}, cb)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cbs *chargebacksSuite) TestChargebacksService_List() {
+func TestChargebacksService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *ChargebacksListOptions
@@ -159,8 +159,8 @@ func (cbs *chargebacksSuite) TestChargebacksService_List() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cbs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cbs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -180,8 +180,8 @@ func (cbs *chargebacksSuite) TestChargebacksService_List() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cbs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cbs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -228,25 +228,28 @@ func (cbs *chargebacksSuite) TestChargebacksService_List() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		cbs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			tMux.HandleFunc("/v2/chargebacks", c.handler)
 
 			c.pre()
 			res, cbl, err := tClient.Chargebacks.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				cbs.Error(err)
-				cbs.EqualError(err, c.err.Error())
+				assert.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cbs.Nil(err)
-				cbs.Same(c.args.ctx, res.Request.Context())
-				cbs.IsType(&ChargebacksList{}, cbl)
-				cbs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &ChargebacksList{}, cbl)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cbs *chargebacksSuite) TestChargebacksService_ListForPayment() {
+func TestChargebacksService_ListForPayment(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -271,8 +274,8 @@ func (cbs *chargebacksSuite) TestChargebacksService_ListForPayment() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cbs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cbs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -293,8 +296,8 @@ func (cbs *chargebacksSuite) TestChargebacksService_ListForPayment() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cbs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cbs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -344,7 +347,7 @@ func (cbs *chargebacksSuite) TestChargebacksService_ListForPayment() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		cbs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			tMux.HandleFunc(
 				fmt.Sprintf("/v2/payments/%s/chargebacks", c.args.payment),
 				c.handler,
@@ -354,18 +357,14 @@ func (cbs *chargebacksSuite) TestChargebacksService_ListForPayment() {
 
 			res, cbl, err := tClient.Chargebacks.ListForPayment(c.args.ctx, c.args.payment, c.args.options)
 			if c.wantErr {
-				cbs.Error(err)
-				cbs.EqualError(err, c.err.Error())
+				assert.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cbs.Nil(err)
-				cbs.Same(c.args.ctx, res.Request.Context())
-				cbs.IsType(&ChargebacksList{}, cbl)
-				cbs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &ChargebacksList{}, cbl)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestChargebacksService(t *testing.T) {
-	suite.Run(t, new(chargebacksSuite))
 }

--- a/mollie/client_links_test.go
+++ b/mollie/client_links_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestCreateClientLink(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 		cd  *ClientDetails

--- a/mollie/client_links_test.go
+++ b/mollie/client_links_test.go
@@ -7,16 +7,10 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type clientLinkSuite struct{ suite.Suite }
-
-func (cls *clientLinkSuite) SetupSuite() { setEnv() }
-
-func (cls *clientLinkSuite) TearDownSuite() { unsetEnv() }
-
-func (cls *clientLinkSuite) TestCreateClientLink() {
+func TestCreateClientLink(t *testing.T) {
 	type args struct {
 		ctx context.Context
 		cd  *ClientDetails
@@ -39,8 +33,8 @@ func (cls *clientLinkSuite) TestCreateClientLink() {
 			false,
 			nil,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cls.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cls.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -87,7 +81,7 @@ func (cls *clientLinkSuite) TestCreateClientLink() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		cls.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			tMux.HandleFunc(
 				"/v2/client-links",
 				c.handler,
@@ -96,19 +90,19 @@ func (cls *clientLinkSuite) TestCreateClientLink() {
 
 			res, cb, err := tClient.ClientLinks.CreateClientLink(c.args.ctx, c.args.cd)
 			if c.wantErr {
-				cls.Error(err)
-				cls.EqualError(err, c.err.Error())
+				assert.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cls.Nil(err)
-				cls.Same(c.args.ctx, res.Request.Context())
-				cls.IsType(&ClientLink{}, cb)
-				cls.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &ClientLink{}, cb)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cls *clientLinkSuite) TestCreateFinalizeClientLink() {
+func TestCreateFinalizeClientLink(t *testing.T) {
 	type args struct {
 		ctx        context.Context
 		clientLink string
@@ -156,15 +150,11 @@ func (cls *clientLinkSuite) TestCreateFinalizeClientLink() {
 		},
 	}
 	for _, tt := range tests {
-		cls.T().Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			gotClientLinkURI := tClient.ClientLinks.CreateFinalizeClientLink(tt.args.ctx, tt.args.clientLink, tt.args.options)
 			if gotClientLinkURI != tt.wantClientLinkURI {
 				t.Errorf("ClientLinksService.CreateFinalizeClientLink() = %v, want %v", gotClientLinkURI, tt.wantClientLinkURI)
 			}
 		})
 	}
-}
-
-func TestClientLinks(t *testing.T) {
-	suite.Run(t, new(clientLinkSuite))
 }

--- a/mollie/customers_test.go
+++ b/mollie/customers_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type customersTestSuite struct{ suite.Suite }
+func TestCustomerService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (cs *customersTestSuite) SetupSuite() { setEnv() }
-
-func (cs *customersTestSuite) TearDownSuite() { unsetEnv() }
-
-func (cs *customersTestSuite) TestCustomerService_Get() {
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -40,8 +37,8 @@ func (cs *customersTestSuite) TestCustomerService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -85,26 +82,28 @@ func (cs *customersTestSuite) TestCustomerService_Get() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s", c.args.customer), c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.Get(c.args.ctx, c.args.customer)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&Customer{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Customer{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomersService_Create() {
+func TestCustomersService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 	type args struct {
 		ctx      context.Context
 		customer Customer
@@ -130,8 +129,8 @@ func (cs *customersTestSuite) TestCustomersService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -178,26 +177,29 @@ func (cs *customersTestSuite) TestCustomersService_Create() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc("/v2/customers", c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.Create(c.args.ctx, c.args.customer)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&Customer{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Customer{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomersService_Update() {
+func TestCustomersService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		customerID string
@@ -225,8 +227,8 @@ func (cs *customersTestSuite) TestCustomersService_Update() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -276,26 +278,28 @@ func (cs *customersTestSuite) TestCustomersService_Update() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s", c.args.customerID), c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.Update(c.args.ctx, c.args.customerID, c.args.customer)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&Customer{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Customer{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomersService_List() {
+func TestCustomersService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 	type args struct {
 		ctx     context.Context
 		options *CustomersListOptions
@@ -323,8 +327,8 @@ func (cs *customersTestSuite) TestCustomersService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -343,8 +347,8 @@ func (cs *customersTestSuite) TestCustomersService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -395,26 +399,28 @@ func (cs *customersTestSuite) TestCustomersService_List() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc("/v2/customers", c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&CustomersList{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &CustomersList{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomersService_Delete() {
+func TestCustomersService_Delete(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -440,8 +446,8 @@ func (cs *customersTestSuite) TestCustomersService_Delete() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -476,25 +482,27 @@ func (cs *customersTestSuite) TestCustomersService_Delete() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s", c.args.customer), c.handler)
 			c.pre()
 			res, err := tClient.Customers.Delete(c.args.ctx, c.args.customer)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomerService_GetPayments() {
+func TestCustomerService_GetPayments(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -520,8 +528,8 @@ func (cs *customersTestSuite) TestCustomerService_GetPayments() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -540,8 +548,8 @@ func (cs *customersTestSuite) TestCustomerService_GetPayments() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -588,26 +596,28 @@ func (cs *customersTestSuite) TestCustomerService_GetPayments() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/payments", c.args.customer), c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.GetPayments(c.args.ctx, c.args.customer, c.args.options)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.IsType(&PaymentList{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentList{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (cs *customersTestSuite) TestCustomerService_CreatePayment() {
+func TestCustomerService_CreatePayment(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -633,8 +643,8 @@ func (cs *customersTestSuite) TestCustomerService_CreatePayment() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(cs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(cs.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -681,26 +691,22 @@ func (cs *customersTestSuite) TestCustomerService_CreatePayment() {
 	}
 
 	for _, c := range cases {
-		cs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			setup()
 			defer teardown()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/payments", c.args.customer), c.handler)
 			c.pre()
 			res, cc, err := tClient.Customers.CreatePayment(c.args.ctx, c.args.customer, c.args.payment)
 			if c.wantErr {
-				cs.NotNil(err)
-				cs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				cs.Nil(err)
-				cs.Nil(err)
-				cs.IsType(&Payment{}, cc)
-				cs.Same(c.args.ctx, res.Request.Context())
-				cs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, cc)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestCustomersService(t *testing.T) {
-	suite.Run(t, new(customersTestSuite))
 }

--- a/mollie/invoices_test.go
+++ b/mollie/invoices_test.go
@@ -9,16 +9,13 @@ import (
 	"time"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type invoiceServiceSuite struct{ suite.Suite }
+func TestInvoicesService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (is *invoiceServiceSuite) SetupSuite() { setEnv() }
-
-func (is *invoiceServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (is *invoiceServiceSuite) TestInvoicesService_Get() {
 	type args struct {
 		ctx     context.Context
 		invoice string
@@ -44,8 +41,8 @@ func (is *invoiceServiceSuite) TestInvoicesService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(is.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(is.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -95,25 +92,28 @@ func (is *invoiceServiceSuite) TestInvoicesService_Get() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		is.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/invoices/%s", c.args.invoice), c.handler)
 
 			res, i, err := tClient.Invoices.Get(c.args.ctx, c.args.invoice)
 			if c.wantErr {
-				is.NotNil(err)
-				is.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				is.Nil(err)
-				is.IsType(&Invoice{}, i)
-				is.Same(c.args.ctx, res.Request.Context())
-				is.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Invoice{}, i)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (is *invoiceServiceSuite) TestInvoicesService_List() {
+func TestInvoicesService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		invoice string
@@ -139,8 +139,8 @@ func (is *invoiceServiceSuite) TestInvoicesService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(is.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(is.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -162,8 +162,8 @@ func (is *invoiceServiceSuite) TestInvoicesService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(is.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(is.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -213,24 +213,20 @@ func (is *invoiceServiceSuite) TestInvoicesService_List() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		is.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/invoices", c.handler)
 
 			res, i, err := tClient.Invoices.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				is.NotNil(err)
-				is.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				is.Nil(err)
-				is.IsType(&InvoicesList{}, i)
-				is.Same(c.args.ctx, res.Request.Context())
-				is.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &InvoicesList{}, i)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestInvoicesService(t *testing.T) {
-	suite.Run(t, new(invoiceServiceSuite))
 }

--- a/mollie/mandates_test.go
+++ b/mollie/mandates_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type mandateServiceSuite struct{ suite.Suite }
+func TestMandatesService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ms *mandateServiceSuite) SetupSuite() { setEnv() }
-
-func (ms *mandateServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ms *mandateServiceSuite) TestMandatesService_Get() {
 	type args struct {
 		ctx      context.Context
 		mandate  string
@@ -42,8 +39,8 @@ func (ms *mandateServiceSuite) TestMandatesService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -92,7 +89,7 @@ func (ms *mandateServiceSuite) TestMandatesService_Get() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(
 				fmt.Sprintf(
@@ -105,19 +102,22 @@ func (ms *mandateServiceSuite) TestMandatesService_Get() {
 
 			res, m, err := tClient.Mandates.Get(c.args.ctx, c.args.customer, c.args.mandate)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&Mandate{}, m)
-				ms.Same(c.args.ctx, res.Request.Context())
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Mandate{}, m)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ms *mandateServiceSuite) TestMandatesService_Create() {
+func TestMandatesService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		mandate  Mandate
@@ -145,8 +145,8 @@ func (ms *mandateServiceSuite) TestMandatesService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -202,7 +202,7 @@ func (ms *mandateServiceSuite) TestMandatesService_Create() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(
 				fmt.Sprintf(
@@ -214,19 +214,22 @@ func (ms *mandateServiceSuite) TestMandatesService_Create() {
 
 			res, m, err := tClient.Mandates.Create(c.args.ctx, c.args.customer, c.args.mandate)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&Mandate{}, m)
-				ms.Same(c.args.ctx, res.Request.Context())
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Mandate{}, m)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ms *mandateServiceSuite) TestMandatesService_Revoke() {
+func TestMandatesService_Revoke(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		mandate  string
@@ -252,8 +255,8 @@ func (ms *mandateServiceSuite) TestMandatesService_Revoke() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -291,7 +294,7 @@ func (ms *mandateServiceSuite) TestMandatesService_Revoke() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(
 				fmt.Sprintf(
@@ -304,18 +307,21 @@ func (ms *mandateServiceSuite) TestMandatesService_Revoke() {
 
 			res, err := tClient.Mandates.Revoke(c.args.ctx, c.args.customer, c.args.mandate)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.Same(c.args.ctx, res.Request.Context())
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ms *mandateServiceSuite) TestMandatesService_List() {
+func TestMandatesService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		options  *MandatesListOptions
@@ -341,8 +347,8 @@ func (ms *mandateServiceSuite) TestMandatesService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -362,8 +368,8 @@ func (ms *mandateServiceSuite) TestMandatesService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
 				}
@@ -412,7 +418,7 @@ func (ms *mandateServiceSuite) TestMandatesService_List() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(
 				fmt.Sprintf(
@@ -424,18 +430,14 @@ func (ms *mandateServiceSuite) TestMandatesService_List() {
 
 			res, m, err := tClient.Mandates.List(c.args.ctx, c.args.customer, c.args.options)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&MandatesList{}, m)
-				ms.Same(c.args.ctx, res.Request.Context())
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &MandatesList{}, m)
+				assert.EqualValues(t, c.args.ctx, res.Request.Context())
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestMandatesService(t *testing.T) {
-	suite.Run(t, new(mandateServiceSuite))
 }

--- a/mollie/miscellaneous_test.go
+++ b/mollie/miscellaneous_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type miscellaneousServiceSuite struct{ suite.Suite }
+func TestMiscellaneousService_ApplePaymentSession(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ms *miscellaneousServiceSuite) SetupSuite() { setEnv() }
-
-func (ms *miscellaneousServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ms *miscellaneousServiceSuite) TestMiscellaneousService_ApplePaymentSession() {
 	type args struct {
 		ctx       context.Context
 		appleSess *ApplePaymentSessionRequest
@@ -42,8 +39,8 @@ func (ms *miscellaneousServiceSuite) TestMiscellaneousService_ApplePaymentSessio
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -90,23 +87,19 @@ func (ms *miscellaneousServiceSuite) TestMiscellaneousService_ApplePaymentSessio
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/wallets/applepay/sessions", c.handler)
 
 			res, m, err := tClient.Miscellaneous.ApplePaymentSession(c.args.ctx, c.args.appleSess)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&ApplePaymentSession{}, m)
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &ApplePaymentSession{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestMiscellaneousService(t *testing.T) {
-	suite.Run(t, new(miscellaneousServiceSuite))
 }

--- a/mollie/mollie_test.go
+++ b/mollie/mollie_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -459,19 +458,19 @@ func TestCheckResponse(t *testing.T) {
 	res1 := &http.Response{
 		StatusCode: http.StatusNotFound,
 		Status:     http.StatusText(http.StatusNotFound),
-		Body:       ioutil.NopCloser(strings.NewReader("not found ok")),
+		Body:       io.NopCloser(strings.NewReader("not found ok")),
 	}
 
 	res3 := &http.Response{
 		StatusCode: http.StatusNotFound,
 		Status:     http.StatusText(http.StatusNotFound),
-		Body:       ioutil.NopCloser(strings.NewReader("")),
+		Body:       io.NopCloser(strings.NewReader("")),
 	}
 
 	res2 := &http.Response{
 		StatusCode: http.StatusOK,
 		Status:     http.StatusText(http.StatusOK),
-		Body:       ioutil.NopCloser(strings.NewReader("success ok")),
+		Body:       io.NopCloser(strings.NewReader("success ok")),
 	}
 
 	tests := []struct {

--- a/mollie/onboarding_test.go
+++ b/mollie/onboarding_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type onboardingServiceSuite struct{ suite.Suite }
+func TestOnboardingService_GetOnboardingStatus(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (os *onboardingServiceSuite) SetupSuite() { setEnv() }
-
-func (os *onboardingServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (os *onboardingServiceSuite) TestOnboardingService_GetOnboardingStatus() {
 	cases := []struct {
 		name    string
 		wantErr bool
@@ -30,8 +27,8 @@ func (os *onboardingServiceSuite) TestOnboardingService_GetOnboardingStatus() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -66,24 +63,27 @@ func (os *onboardingServiceSuite) TestOnboardingService_GetOnboardingStatus() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/onboarding/me", c.handler)
 
 			res, m, err := tClient.Onboarding.GetOnboardingStatus(context.Background())
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Onboarding{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Onboarding{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *onboardingServiceSuite) TestOnboardingService_SubmitOnboardingData() {
+func TestOnboardingService_SubmitOnboardingData(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	cases := []struct {
 		name    string
 		data    *OnboardingData
@@ -99,8 +99,8 @@ func (os *onboardingServiceSuite) TestOnboardingService_SubmitOnboardingData() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -130,22 +130,18 @@ func (os *onboardingServiceSuite) TestOnboardingService_SubmitOnboardingData() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/onboarding/me", c.handler)
 
 			res, err := tClient.Onboarding.SubmitOnboardingData(context.Background(), c.data)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestOnboardingService(t *testing.T) {
-	suite.Run(t, new(onboardingServiceSuite))
 }

--- a/mollie/orders_test.go
+++ b/mollie/orders_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type ordersServiceSuite struct{ suite.Suite }
+func TestOrdersService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (os *ordersServiceSuite) SetupSuite() { setEnv() }
-
-func (os *ordersServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (os *ordersServiceSuite) TestOrdersService_Get() {
 	type args struct {
 		ctx     context.Context
 		order   string
@@ -43,9 +40,9 @@ func (os *ordersServiceSuite) TestOrdersService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "profileId=pfl_1236h213bv1")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "profileId=pfl_1236h213bv1")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -95,24 +92,27 @@ func (os *ordersServiceSuite) TestOrdersService_Get() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s", c.args.order), c.handler)
 
 			res, m, err := tClient.Orders.Get(c.args.ctx, c.args.order, c.args.options)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_List() {
+func TestOrdersService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   string
@@ -139,9 +139,9 @@ func (os *ordersServiceSuite) TestOrdersService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "profileId=pfl_1236h213bv1")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "profileId=pfl_1236h213bv1")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -191,24 +191,27 @@ func (os *ordersServiceSuite) TestOrdersService_List() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/orders", c.handler)
 
 			res, m, err := tClient.Orders.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&OrderList{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &OrderList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_Create() {
+func TestOrdersService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   Order
@@ -235,8 +238,8 @@ func (os *ordersServiceSuite) TestOrdersService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -259,8 +262,8 @@ func (os *ordersServiceSuite) TestOrdersService_Create() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -316,24 +319,27 @@ func (os *ordersServiceSuite) TestOrdersService_Create() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/orders", c.handler)
 
 			res, m, err := tClient.Orders.Create(c.args.ctx, c.args.order, c.args.options)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_Update() {
+func TestOrdersService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   Order
@@ -361,8 +367,8 @@ func (os *ordersServiceSuite) TestOrdersService_Update() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -385,8 +391,8 @@ func (os *ordersServiceSuite) TestOrdersService_Update() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -442,24 +448,27 @@ func (os *ordersServiceSuite) TestOrdersService_Update() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s", c.args.order.ID), c.handler)
 
 			res, m, err := tClient.Orders.Update(c.args.ctx, c.args.order.ID, c.args.order)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_Cancel() {
+func TestOrdersService_Cancel(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   Order
@@ -487,8 +496,8 @@ func (os *ordersServiceSuite) TestOrdersService_Cancel() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -511,8 +520,8 @@ func (os *ordersServiceSuite) TestOrdersService_Cancel() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -568,24 +577,27 @@ func (os *ordersServiceSuite) TestOrdersService_Cancel() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s", c.args.order.ID), c.handler)
 
 			res, m, err := tClient.Orders.Cancel(c.args.ctx, c.args.order.ID)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
+func TestOrdersService_UpdateOrderLine(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx   context.Context
 		order string
@@ -613,8 +625,8 @@ func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -638,8 +650,8 @@ func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -698,24 +710,27 @@ func (os *ordersServiceSuite) TestOrdersService_UpdateOrderLine() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/lines/%s", c.args.order, c.args.line.ID), c.handler)
 
 			res, m, err := tClient.Orders.UpdateOrderLine(c.args.ctx, c.args.order, c.args.line.ID, c.args.line)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
+func TestOrdersService_CancelOrderLine(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx   context.Context
 		order string
@@ -743,8 +758,8 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -768,8 +783,8 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -813,7 +828,7 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/lines", c.args.order), c.handler)
 
@@ -823,17 +838,20 @@ func (os *ordersServiceSuite) TestOrdersService_CancelOrderLine() {
 
 			res, err := tClient.Orders.CancelOrderLines(c.args.ctx, c.args.order, l)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
+func TestOrdersService_CreateOrderPayment(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   string
@@ -861,8 +879,8 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -886,8 +904,8 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -937,24 +955,27 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderPayment() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/payments", c.args.order), c.handler)
 
 			res, m, err := tClient.Orders.CreateOrderPayment(c.args.ctx, c.args.order, c.args.payment)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Payment{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
+func TestOrdersService_CreateOrderRefund(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx   context.Context
 		order *Order
@@ -977,8 +998,8 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -998,8 +1019,8 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1046,24 +1067,27 @@ func (os *ordersServiceSuite) TestOrdersService_CreateOrderRefund() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/refunds", c.args.order.ID), c.handler)
 
 			res, m, err := tClient.Orders.CreateOrderRefund(c.args.ctx, c.args.order.ID, c.args.order)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Refund{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Refund{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
+func TestOrdersService_ListOrderRefund(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		order   *Order
@@ -1088,9 +1112,9 @@ func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "limit=100")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=100")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1111,8 +1135,8 @@ func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1162,24 +1186,27 @@ func (os *ordersServiceSuite) TestOrdersService_ListOrderRefund() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/refunds", c.args.order.ID), c.handler)
 
 			res, m, err := tClient.Orders.ListOrderRefunds(c.args.ctx, c.args.order.ID, c.args.options)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&OrderListRefund{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &OrderListRefund{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *ordersServiceSuite) TestOrdersService_ManageOrderLines() {
+func TestOrdersService_ManageOrderLines(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		order      string
@@ -1214,8 +1241,8 @@ func (os *ordersServiceSuite) TestOrdersService_ManageOrderLines() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1246,8 +1273,8 @@ func (os *ordersServiceSuite) TestOrdersService_ManageOrderLines() {
 				tClient.WithAuthenticationValue("access_token_test")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(os.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1327,23 +1354,19 @@ func (os *ordersServiceSuite) TestOrdersService_ManageOrderLines() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/lines", c.args.order), c.handler)
 
 			res, m, err := tClient.Orders.ManageOrderLines(c.args.ctx, c.args.order, c.args.operations)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Order{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Order{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestOrdersService(t *testing.T) {
-	suite.Run(t, new(ordersServiceSuite))
 }

--- a/mollie/organizations_test.go
+++ b/mollie/organizations_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type organizationsServiceSuite struct{ suite.Suite }
+func TestOrganizationsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (os *organizationsServiceSuite) SetupSuite() { setEnv() }
-
-func (os *organizationsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (os *organizationsServiceSuite) TestOrganizationsService_Get() {
 	type args struct {
 		ctx          context.Context
 		organization string
@@ -40,8 +37,8 @@ func (os *organizationsServiceSuite) TestOrganizationsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -88,24 +85,27 @@ func (os *organizationsServiceSuite) TestOrganizationsService_Get() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/organizations/%s", c.args.organization), c.handler)
 
 			res, m, err := tClient.Organizations.Get(c.args.ctx, c.args.organization)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Organization{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Organization{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *organizationsServiceSuite) TestOrganizationsService_GetCurrent() {
+func TestOrganizationsService_GetCurrent(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 	}
@@ -127,8 +127,8 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetCurrent() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -172,24 +172,27 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetCurrent() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/organizations/me", c.handler)
 
 			res, m, err := tClient.Organizations.GetCurrent(c.args.ctx)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&Organization{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Organization{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *organizationsServiceSuite) TestOrganizationsService_GetPartnerStatus() {
+func TestOrganizationsService_GetPartnerStatus(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 	}
@@ -211,8 +214,8 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetPartnerStatus()
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -256,23 +259,19 @@ func (os *organizationsServiceSuite) TestOrganizationsService_GetPartnerStatus()
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/organizations/me/partner", c.handler)
 
 			res, m, err := tClient.Organizations.GetPartnerStatus(c.args.ctx)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&OrganizationPartnerStatus{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &OrganizationPartnerStatus{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestOrganizationsService(t *testing.T) {
-	suite.Run(t, new(organizationsServiceSuite))
 }

--- a/mollie/partners_test.go
+++ b/mollie/partners_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type partnersServiceSuite struct{ suite.Suite }
+func TestPartnerService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (os *partnersServiceSuite) SetupSuite() { setEnv() }
-
-func (os *partnersServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (os *partnersServiceSuite) TestPartnerService_Get() {
 	type args struct {
 		ctx    context.Context
 		client string
@@ -42,8 +39,8 @@ func (os *partnersServiceSuite) TestPartnerService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -64,9 +61,9 @@ func (os *partnersServiceSuite) TestPartnerService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "embed=organization")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "embed=organization")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -116,24 +113,27 @@ func (os *partnersServiceSuite) TestPartnerService_Get() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/clients/%s", c.args.client), c.handler)
 
 			res, m, err := tClient.Partners.Get(c.args.ctx, c.args.client, c.args.opts)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&PartnerClient{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PartnerClient{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (os *partnersServiceSuite) TestPartnerService_List() {
+func TestPartnerService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx    context.Context
 		client string
@@ -159,8 +159,8 @@ func (os *partnersServiceSuite) TestPartnerService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -181,9 +181,9 @@ func (os *partnersServiceSuite) TestPartnerService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(os.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(os.T(), r, "GET")
-				testQuery(os.T(), r, "year=2021")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "year=2021")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -233,23 +233,19 @@ func (os *partnersServiceSuite) TestPartnerService_List() {
 		setup()
 		defer teardown()
 
-		os.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/clients", c.handler)
 
 			res, m, err := tClient.Partners.List(c.args.ctx, c.args.opts)
 			if c.wantErr {
-				os.NotNil(err)
-				os.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				os.Nil(err)
-				os.IsType(&PartnerClientList{}, m)
-				os.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PartnerClientList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestPartnersService(t *testing.T) {
-	suite.Run(t, new(partnersServiceSuite))
 }

--- a/mollie/payment_links_test.go
+++ b/mollie/payment_links_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type paymentLinksSuite struct{ suite.Suite }
+func TestPaymentLinkService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *paymentLinksSuite) SetupSuite() { setEnv() }
-
-func (ps *paymentLinksSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *paymentLinksSuite) TestPaymentLinkService_Get() {
 	type args struct {
 		ctx         context.Context
 		paymentLink string
@@ -42,8 +39,8 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -93,24 +90,27 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payment-links/%s", c.args.paymentLink), c.handler)
 
 			res, m, err := tClient.PaymentLinks.Get(c.args.ctx, c.args.paymentLink)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentLink{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentLink{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentLinksSuite) TestPaymentLinkService_Create() {
+func TestPaymentLinkService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx         context.Context
 		paymentLink PaymentLink
@@ -138,9 +138,9 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "profileId=prf_12312312")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "profileId=prf_12312312")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -190,24 +190,27 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_Create() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/payment-links", c.handler)
 
 			res, m, err := tClient.PaymentLinks.Create(c.args.ctx, c.args.paymentLink, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentLink{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentLink{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
+func TestPaymentLinkService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx  context.Context
 		opts *PaymentLinkOptions
@@ -231,8 +234,8 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -252,9 +255,9 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "profileId=pfl_11211")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "profileId=pfl_11211")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -301,23 +304,19 @@ func (ps *paymentLinksSuite) TestPaymentLinkService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/payment-links", c.handler)
 
 			res, m, err := tClient.PaymentLinks.List(c.args.ctx, c.args.opts)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentLinksList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentLinksList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestPaymentLinksService(t *testing.T) {
-	suite.Run(t, new(paymentLinksSuite))
 }

--- a/mollie/payment_methods_test.go
+++ b/mollie/payment_methods_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type paymentMethodsServiceSuite struct{ suite.Suite }
+func TestMethodsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ms *paymentMethodsServiceSuite) SetupSuite() { setEnv() }
-
-func (ms *paymentMethodsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 	type args struct {
 		ctx     context.Context
 		options *PaymentMethodsListOptions
@@ -40,8 +37,8 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -62,9 +59,9 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -111,24 +108,27 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_List() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/methods", c.handler)
 
 			res, m, err := tClient.PaymentMethods.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&PaymentMethodsList{}, m)
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentMethodsList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
+func TestMethodsService_All(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *PaymentMethodsListOptions
@@ -152,8 +152,8 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -174,9 +174,9 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=100.00")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -223,24 +223,27 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_All() {
 		setup()
 		defer teardown()
 
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/methods/all", c.handler)
 
 			res, m, err := tClient.PaymentMethods.All(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&PaymentMethodsList{}, m)
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentMethodsList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
+func TestMethodsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *PaymentMethodOptions
@@ -266,8 +269,8 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -286,9 +289,9 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ms.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ms.T(), r, "GET")
-				testQuery(ms.T(), r, "locale=ca_ES")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "locale=ca_ES")
 
 				fmt.Println(r.Context())
 
@@ -339,23 +342,19 @@ func (ms *paymentMethodsServiceSuite) TestMethodsService_Get() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		ms.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/methods/%s", c.args.method), c.handler)
 
 			res, m, err := tClient.PaymentMethods.Get(c.args.ctx, c.args.method, c.args.options)
 			if c.wantErr {
-				ms.NotNil(err)
-				ms.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ms.Nil(err)
-				ms.IsType(&PaymentMethodDetails{}, m)
-				ms.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentMethodDetails{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestMethodsService(t *testing.T) {
-	suite.Run(t, new(paymentMethodsServiceSuite))
 }

--- a/mollie/payments_test.go
+++ b/mollie/payments_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type paymentsServiceSuite struct{ suite.Suite }
+func TestPaymentsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *paymentsServiceSuite) SetupSuite() { setEnv() }
-
-func (ps *paymentsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *paymentsServiceSuite) TestPaymentsService_Get() {
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -43,9 +40,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "include=settlements")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "include=settlements")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -95,24 +92,27 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s", c.args.payment), c.handler)
 
 			res, m, err := tClient.Payments.Get(c.args.ctx, c.args.payment, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Payment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentsServiceSuite) TestPaymentsService_List() {
+func TestPaymentsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *ListPaymentOptions
@@ -137,9 +137,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "from=tr_12o93213")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "from=tr_12o93213")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -186,24 +186,27 @@ func (ps *paymentsServiceSuite) TestPaymentsService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/payments", c.handler)
 
 			res, m, err := tClient.Payments.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
+func TestPaymentsService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment Payment
@@ -232,9 +235,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "include=settlements")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "include=settlements")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -257,9 +260,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "include=settlements&testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "include=settlements&testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -309,24 +312,27 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Create() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/payments", c.handler)
 
 			res, m, err := tClient.Payments.Create(c.args.ctx, c.args.payment, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Payment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentsServiceSuite) TestPaymentsService_Update() {
+func TestPaymentsService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		id      string
@@ -353,8 +359,8 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Update() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -377,9 +383,9 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Update() {
 				tClient.WithAuthenticationValue("access_example_token")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_example_token")
-				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_example_token")
+				testMethod(t, r, "PATCH")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -429,24 +435,27 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Update() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s", c.args.id), c.handler)
 
 			res, m, err := tClient.Payments.Update(c.args.ctx, c.args.id, c.args.payment)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Payment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *paymentsServiceSuite) TestPaymentsService_Cancel() {
+func TestPaymentsService_Cancel(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 		id  string
@@ -469,8 +478,8 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Cancel() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -517,23 +526,19 @@ func (ps *paymentsServiceSuite) TestPaymentsService_Cancel() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s", c.args.id), c.handler)
 
 			res, m, err := tClient.Payments.Cancel(c.args.ctx, c.args.id)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Payment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Payment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestPaymentsService(t *testing.T) {
-	suite.Run(t, new(paymentsServiceSuite))
 }

--- a/mollie/permissions_test.go
+++ b/mollie/permissions_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type permissionsServiceSuite struct{ suite.Suite }
+func TestPermissionsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (os *permissionsServiceSuite) SetupSuite() { setEnv() }
-
-func (os *permissionsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *permissionsServiceSuite) TestPermissionsService_Get() {
 	type args struct {
 		ctx        context.Context
 		permission PermissionGrant
@@ -41,9 +38,9 @@ func (ps *permissionsServiceSuite) TestPermissionsService_Get() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -90,24 +87,27 @@ func (ps *permissionsServiceSuite) TestPermissionsService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/permissions/%s", c.args.permission), c.handler)
 
 			res, m, err := tClient.Permissions.Get(c.args.ctx, c.args.permission)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Permission{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Permission{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *permissionsServiceSuite) TestPermissionsService_List() {
+func TestPermissionsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx context.Context
 	}
@@ -128,8 +128,8 @@ func (ps *permissionsServiceSuite) TestPermissionsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -174,23 +174,19 @@ func (ps *permissionsServiceSuite) TestPermissionsService_List() {
 	for _, c := range cases {
 		setup()
 		defer teardown()
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/permissions", c.handler)
 
 			res, m, err := tClient.Permissions.List(c.args.ctx)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PermissionsList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PermissionsList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestPermissionService(t *testing.T) {
-	suite.Run(t, new(permissionsServiceSuite))
 }

--- a/mollie/profiles_test.go
+++ b/mollie/profiles_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type profilesServiceSuite struct{ suite.Suite }
+func TestProfilesService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *profilesServiceSuite) SetupSuite() { setEnv() }
-
-func (ps *profilesServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *profilesServiceSuite) TestProfilesService_Get() {
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -41,9 +38,9 @@ func (ps *profilesServiceSuite) TestProfilesService_Get() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -90,24 +87,27 @@ func (ps *profilesServiceSuite) TestProfilesService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s", c.args.profile), c.handler)
 
 			res, m, err := tClient.Profiles.Get(c.args.ctx, c.args.profile)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Profile{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Profile{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_GetCurrent() {
+func TestProfilesService_GetCurrent(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	cases := []struct {
 		name    string
 		wantErr bool
@@ -123,9 +123,9 @@ func (ps *profilesServiceSuite) TestProfilesService_GetCurrent() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -160,24 +160,27 @@ func (ps *profilesServiceSuite) TestProfilesService_GetCurrent() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s", "me"), c.handler)
 
 			res, m, err := tClient.Profiles.Current(context.Background())
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Profile{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Profile{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_List() {
+func TestProfilesService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *ProfileListOptions
@@ -202,9 +205,9 @@ func (ps *profilesServiceSuite) TestProfilesService_List() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -226,9 +229,9 @@ func (ps *profilesServiceSuite) TestProfilesService_List() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=100&testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=100&testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -275,24 +278,27 @@ func (ps *profilesServiceSuite) TestProfilesService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/profiles", c.handler)
 
 			res, m, err := tClient.Profiles.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&ProfileList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &ProfileList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_Create() {
+func TestProfilesService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile *Profile
@@ -319,9 +325,9 @@ func (ps *profilesServiceSuite) TestProfilesService_Create() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -368,24 +374,27 @@ func (ps *profilesServiceSuite) TestProfilesService_Create() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/profiles", c.handler)
 
 			res, m, err := tClient.Profiles.Create(c.args.ctx, c.args.profile)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Profile{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Profile{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_Update() {
+func TestProfilesService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx       context.Context
 		profileID string
@@ -414,9 +423,9 @@ func (ps *profilesServiceSuite) TestProfilesService_Update() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "PATCH")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -466,24 +475,27 @@ func (ps *profilesServiceSuite) TestProfilesService_Update() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s", c.args.profileID), c.handler)
 
 			res, m, err := tClient.Profiles.Update(c.args.ctx, c.args.profileID, c.args.profile)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Profile{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Profile{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_Delete() {
+func TestProfilesService_Delete(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -508,9 +520,9 @@ func (ps *profilesServiceSuite) TestProfilesService_Delete() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "DELETE")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -546,23 +558,26 @@ func (ps *profilesServiceSuite) TestProfilesService_Delete() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s", c.args.profile), c.handler)
 
 			res, err := tClient.Profiles.Delete(c.args.ctx, c.args.profile)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_EnablePaymentMethod() {
+func TestProfilesService_EnablePaymentMethod(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -589,9 +604,9 @@ func (ps *profilesServiceSuite) TestProfilesService_EnablePaymentMethod() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -641,24 +656,27 @@ func (ps *profilesServiceSuite) TestProfilesService_EnablePaymentMethod() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s/methods/%s", c.args.profile, c.args.method), c.handler)
 
 			res, m, err := tClient.Profiles.EnablePaymentMethod(c.args.ctx, c.args.profile, c.args.method)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentMethodDetails{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentMethodDetails{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_DisablePaymentMethod() {
+func TestProfilesService_DisablePaymentMethod(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -685,9 +703,9 @@ func (ps *profilesServiceSuite) TestProfilesService_DisablePaymentMethod() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "DELETE")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -726,23 +744,26 @@ func (ps *profilesServiceSuite) TestProfilesService_DisablePaymentMethod() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s/methods/%s", c.args.profile, c.args.method), c.handler)
 
 			res, err := tClient.Profiles.DisablePaymentMethod(c.args.ctx, c.args.profile, c.args.method)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuer() {
+func TestProfilesService_EnableGiftCardIssuer(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -769,9 +790,9 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuer() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -821,24 +842,27 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuer() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s/methods/giftcard/issuers/%s", c.args.profile, c.args.issuer), c.handler)
 
 			res, m, err := tClient.Profiles.EnableGiftCardIssuer(c.args.ctx, c.args.profile, c.args.issuer)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&GiftCardEnabled{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &GiftCardEnabled{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuer() {
+func TestProfilesService_DisableGiftCardIssuer(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		profile string
@@ -865,9 +889,9 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuer() {
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "DELETE")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -906,23 +930,26 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuer() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/%s/methods/giftcard/issuers/%s", c.args.profile, c.args.issuer), c.handler)
 
 			res, err := tClient.Profiles.DisableGiftCardIssuer(c.args.ctx, c.args.profile, c.args.issuer)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuerForCurrent() {
+func TestProfilesService_EnableGiftCardIssuerForCurrent(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx    context.Context
 		issuer GiftCardIssuer
@@ -947,9 +974,9 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuerForCurre
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -996,24 +1023,27 @@ func (ps *profilesServiceSuite) TestProfilesService_EnableGiftCardIssuerForCurre
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/me/methods/giftcard/issuers/%s", c.args.issuer), c.handler)
 
 			res, m, err := tClient.Profiles.EnableGiftCardIssuerForCurrent(c.args.ctx, c.args.issuer)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&GiftCardEnabled{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &GiftCardEnabled{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuerForCurrent() {
+func TestProfilesService_DisableGiftCardIssuerForCurrent(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx    context.Context
 		issuer GiftCardIssuer
@@ -1038,9 +1068,9 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuerForCurr
 				tClient.WithAuthenticationValue("access_X12b31ggg23")
 			},
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_X12b31ggg23")
+				testMethod(t, r, "DELETE")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -1077,22 +1107,18 @@ func (ps *profilesServiceSuite) TestProfilesService_DisableGiftCardIssuerForCurr
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/profiles/me/methods/giftcard/issuers/%s", c.args.issuer), c.handler)
 
 			res, err := tClient.Profiles.DisableGiftCardIssuerForCurrent(c.args.ctx, c.args.issuer)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestProfilesService(t *testing.T) {
-	suite.Run(t, new(profilesServiceSuite))
 }

--- a/mollie/refunds_test.go
+++ b/mollie/refunds_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type refundsServiceTest struct{ suite.Suite }
+func TestRefundsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (rs *refundsServiceTest) SetupSuite() { setEnv() }
-
-func (rs *refundsServiceTest) TearDownSuite() { unsetEnv() }
-
-func (rs *refundsServiceTest) TestRefundsService_Get() {
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -45,9 +42,9 @@ func (rs *refundsServiceTest) TestRefundsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "embed=profile")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "embed=profile")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -100,24 +97,27 @@ func (rs *refundsServiceTest) TestRefundsService_Get() {
 		setup()
 		defer teardown()
 
-		rs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s/refunds/%s", c.args.payment, c.args.refund), c.handler)
 
 			res, m, err := tClient.Refunds.Get(c.args.ctx, c.args.payment, c.args.refund, c.args.options)
 			if c.wantErr {
-				rs.NotNil(err)
-				rs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				rs.Nil(err)
-				rs.IsType(&Refund{}, m)
-				rs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Refund{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (rs *refundsServiceTest) TestRefundsService_Create() {
+func TestRefundsService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -151,9 +151,9 @@ func (rs *refundsServiceTest) TestRefundsService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(rs.T(), r, "POST")
-				testQuery(rs.T(), r, "embed=profile")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "embed=profile")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -178,9 +178,9 @@ func (rs *refundsServiceTest) TestRefundsService_Create() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(rs.T(), r, "POST")
-				testQuery(rs.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -248,24 +248,27 @@ func (rs *refundsServiceTest) TestRefundsService_Create() {
 		setup()
 		defer teardown()
 
-		rs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s/refunds", c.args.payment), c.handler)
 
 			res, m, err := tClient.Refunds.Create(c.args.ctx, c.args.payment, c.args.refund, c.args.options)
 			if c.wantErr {
-				rs.NotNil(err)
-				rs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				rs.Nil(err)
-				rs.IsType(&Refund{}, m)
-				rs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Refund{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (rs *refundsServiceTest) TestRefundsService_Cancel() {
+func TestRefundsService_Cancel(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -290,8 +293,8 @@ func (rs *refundsServiceTest) TestRefundsService_Cancel() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(rs.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -329,23 +332,26 @@ func (rs *refundsServiceTest) TestRefundsService_Cancel() {
 		setup()
 		defer teardown()
 
-		rs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s/refunds/%s", c.args.payment, c.args.refund), c.handler)
 
 			res, err := tClient.Refunds.Cancel(c.args.ctx, c.args.payment, c.args.refund)
 			if c.wantErr {
-				rs.NotNil(err)
-				rs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				rs.Nil(err)
-				rs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (rs *refundsServiceTest) TestRefundsService_List() {
+func TestRefundsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -372,9 +378,9 @@ func (rs *refundsServiceTest) TestRefundsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -424,24 +430,27 @@ func (rs *refundsServiceTest) TestRefundsService_List() {
 		setup()
 		defer teardown()
 
-		rs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/refunds", c.handler)
 
 			res, m, err := tClient.Refunds.ListRefund(c.args.ctx, c.args.options)
 			if c.wantErr {
-				rs.NotNil(err)
-				rs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				rs.Nil(err)
-				rs.IsType(&RefundList{}, m)
-				rs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &RefundList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (rs *refundsServiceTest) TestRefundsService_ListPaynents() {
+func TestRefundsService_ListPaynents(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		payment string
@@ -470,9 +479,9 @@ func (rs *refundsServiceTest) TestRefundsService_ListPaynents() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(rs.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(rs.T(), r, "GET")
-				testQuery(rs.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -525,23 +534,19 @@ func (rs *refundsServiceTest) TestRefundsService_ListPaynents() {
 		setup()
 		defer teardown()
 
-		rs.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/payments/%s/refunds", c.args.payment), c.handler)
 
 			res, m, err := tClient.Refunds.ListRefundPayment(c.args.ctx, c.args.payment, c.args.options)
 			if c.wantErr {
-				rs.NotNil(err)
-				rs.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				rs.Nil(err)
-				rs.IsType(&RefundList{}, m)
-				rs.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &RefundList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestRefundsService(t *testing.T) {
-	suite.Run(t, new(refundsServiceTest))
 }

--- a/mollie/settlements_test.go
+++ b/mollie/settlements_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type settlementsServiceSuite struct{ suite.Suite }
+func TestSettlementsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *settlementsServiceSuite) SetupSuite() { setEnv() }
-
-func (ps *settlementsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *settlementsServiceSuite) TestSettlementsService_Get() {
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -39,8 +36,8 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -87,24 +84,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.Get(c.args.ctx, c.args.settlement)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Settlement{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Settlement{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_Next() {
+func TestSettlementsService_Next(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -127,8 +127,8 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Next() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -175,24 +175,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Next() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.Next(c.args.ctx)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Settlement{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Settlement{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_Open() {
+func TestSettlementsService_Open(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -215,8 +218,8 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Open() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -263,24 +266,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_Open() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.Open(c.args.ctx)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Settlement{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Settlement{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_List() {
+func TestSettlementsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *SettlementsListOptions
@@ -305,9 +311,9 @@ func (ps *settlementsServiceSuite) TestSettlementsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=40")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=40")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -360,24 +366,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/settlements", c.handler)
 
 			res, m, err := tClient.Settlements.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&SettlementsList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &SettlementsList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_GetPayments() {
+func TestSettlementsService_GetPayments(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -404,9 +413,9 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetPayments() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -462,24 +471,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetPayments() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s/payments", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.GetPayments(c.args.ctx, c.args.settlement, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_GetCaptures() {
+func TestSettlementsService_GetCaptures(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -506,9 +518,9 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetCaptures() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -564,24 +576,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetCaptures() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s/captures", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.GetCaptures(c.args.ctx, c.args.settlement, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&CapturesList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &CapturesList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_GetChargebacks() {
+func TestSettlementsService_GetChargebacks(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -608,9 +623,9 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetChargebacks() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -666,24 +681,27 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetChargebacks() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s/chargebacks", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.GetChargebacks(c.args.ctx, c.args.settlement, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&ChargebacksList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &ChargebacksList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *settlementsServiceSuite) TestSettlementsService_GetRefunds() {
+func TestSettlementsService_GetRefunds(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx        context.Context
 		settlement string
@@ -710,9 +728,9 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetRefunds() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -768,23 +786,19 @@ func (ps *settlementsServiceSuite) TestSettlementsService_GetRefunds() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/settlements/%s/refunds", c.args.settlement), c.handler)
 
 			res, m, err := tClient.Settlements.GetRefunds(c.args.ctx, c.args.settlement, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&RefundList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &RefundList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestSettlementsService(t *testing.T) {
-	suite.Run(t, new(settlementsServiceSuite))
 }

--- a/mollie/shipments_test.go
+++ b/mollie/shipments_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type shipmentsServiceSuite struct{ suite.Suite }
+func TestShipmentsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *shipmentsServiceSuite) SetupSuite() { setEnv() }
-
-func (ps *shipmentsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *shipmentsServiceSuite) TestShipmentsService_Get() {
 	type args struct {
 		ctx      context.Context
 		order    string
@@ -41,8 +38,8 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -92,24 +89,27 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/shipments/%s", c.args.order, c.args.shipment), c.handler)
 
 			res, m, err := tClient.Shipments.Get(c.args.ctx, c.args.order, c.args.shipment)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Shipment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Shipment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *shipmentsServiceSuite) TestShipmentsService_List() {
+func TestShipmentsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		order    string
@@ -134,8 +134,8 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -185,24 +185,27 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/shipments", c.args.order), c.handler)
 
 			res, m, err := tClient.Shipments.List(c.args.ctx, c.args.order)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&ShipmentsList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &ShipmentsList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
+func TestShipmentsService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		order    string
@@ -229,8 +232,8 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -251,9 +254,9 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -309,24 +312,27 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Create() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/shipments", c.args.order), c.handler)
 
 			res, m, err := tClient.Shipments.Create(c.args.ctx, c.args.order, c.args.shipment)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Shipment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Shipment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
+func TestShipmentsService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		order    string
@@ -355,8 +361,8 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -378,9 +384,9 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "PATCH")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -439,23 +445,19 @@ func (ps *shipmentsServiceSuite) TestShipmentsService_Update() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/orders/%s/shipments/%s", c.args.order, c.args.shipment), c.handler)
 
 			res, m, err := tClient.Shipments.Update(c.args.ctx, c.args.order, c.args.shipment, c.args.st)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Shipment{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Shipment{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestShipmentsService(t *testing.T) {
-	suite.Run(t, new(shipmentsServiceSuite))
 }

--- a/mollie/subscriptions_test.go
+++ b/mollie/subscriptions_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type subscriptionsServiceSuite struct{ suite.Suite }
+func TestSubscriptionsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ps *subscriptionsServiceSuite) SetupSuite() { setEnv() }
-
-func (ps *subscriptionsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Get() {
 	type args struct {
 		ctx          context.Context
 		customer     string
@@ -41,8 +38,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Get() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -92,24 +89,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Get() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions/%s", c.args.customer, c.args.subscription), c.handler)
 
 			res, m, err := tClient.Subscriptions.Get(c.args.ctx, c.args.customer, c.args.subscription)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Subscription{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Subscription{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Create() {
+func TestSubscriptionsService_Create(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx          context.Context
 		customer     string
@@ -140,8 +140,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Create() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "POST")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -166,9 +166,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Create() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "POST")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "POST")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -236,24 +236,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Create() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions", c.args.customer), c.handler)
 
 			res, m, err := tClient.Subscriptions.Create(c.args.ctx, c.args.customer, c.args.subscription)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Subscription{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Subscription{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Update() {
+func TestSubscriptionsService_Update(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx          context.Context
 		customer     string
@@ -286,8 +289,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Update() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "PATCH")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -313,9 +316,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Update() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "PATCH")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "PATCH")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -386,24 +389,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Update() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions/%s", c.args.customer, c.args.sid), c.handler)
 
 			res, m, err := tClient.Subscriptions.Update(c.args.ctx, c.args.customer, c.args.sid, c.args.subscription)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Subscription{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Subscription{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Delete() {
+func TestSubscriptionsService_Delete(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -428,8 +434,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Delete() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "DELETE")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "DELETE")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -448,9 +454,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Delete() {
 			nil,
 			setAccessToken,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer access_token_test")
-				testMethod(ps.T(), r, "DELETE")
-				testQuery(ps.T(), r, "testmode=true")
+				testHeader(t, r, AuthHeader, "Bearer access_token_test")
+				testMethod(t, r, "DELETE")
+				testQuery(t, r, "testmode=true")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -500,24 +506,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_Delete() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions/%s", c.args.customer, c.args.sid), c.handler)
 
 			res, m, err := tClient.Subscriptions.Delete(c.args.ctx, c.args.customer, c.args.sid)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&Subscription{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Subscription{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
+func TestSubscriptionsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx      context.Context
 		customer string
@@ -542,8 +551,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -564,9 +573,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -616,24 +625,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_List() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions", c.args.customer), c.handler)
 
 			res, m, err := tClient.Subscriptions.List(c.args.ctx, c.args.customer, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&SubscriptionList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &SubscriptionList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
+func TestSubscriptionsService_All(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *SubscriptionListOptions
@@ -656,8 +668,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -677,9 +689,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -726,24 +738,27 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_All() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/subscriptions", c.handler)
 
 			res, m, err := tClient.Subscriptions.All(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&SubscriptionList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &SubscriptionList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
+func TestSubscriptionsService_GetPayments(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx          context.Context
 		customer     string
@@ -770,8 +785,8 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -793,9 +808,9 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
 			nil,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ps.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ps.T(), r, "GET")
-				testQuery(ps.T(), r, "limit=10")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
+				testQuery(t, r, "limit=10")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -848,23 +863,19 @@ func (ps *subscriptionsServiceSuite) TestSubscriptionsService_GetPayments() {
 		setup()
 		defer teardown()
 
-		ps.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/customers/%s/subscriptions/%s/payments", c.args.customer, c.args.subscription), c.handler)
 
 			res, m, err := tClient.Subscriptions.GetPayments(c.args.ctx, c.args.customer, c.args.subscription, c.args.options)
 			if c.wantErr {
-				ps.NotNil(err)
-				ps.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ps.Nil(err)
-				ps.IsType(&PaymentList{}, m)
-				ps.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &PaymentList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestSubscriptionService(t *testing.T) {
-	suite.Run(t, new(subscriptionsServiceSuite))
 }

--- a/mollie/terminals_test.go
+++ b/mollie/terminals_test.go
@@ -7,16 +7,13 @@ import (
 	"testing"
 
 	"github.com/VictorAvelar/mollie-api-go/v4/testdata"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type terminalsServiceSuite struct{ suite.Suite }
+func TestTerminalsService_Get(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
 
-func (ts *terminalsServiceSuite) SetupSuite() { setEnv() }
-
-func (ts *terminalsServiceSuite) TearDownSuite() { unsetEnv() }
-
-func (ts *terminalsServiceSuite) TestTerminalsService_Get() {
 	type args struct {
 		ctx context.Context
 		id  string
@@ -42,8 +39,8 @@ func (ts *terminalsServiceSuite) TestTerminalsService_Get() {
 			testdata.GetTerminalResponse,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ts.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ts.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -93,24 +90,27 @@ func (ts *terminalsServiceSuite) TestTerminalsService_Get() {
 		setup()
 		defer teardown()
 
-		ts.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc(fmt.Sprintf("/v2/terminals/%s", c.args.id), c.handler)
 
 			res, m, err := tClient.Terminals.Get(c.args.ctx, c.args.id)
 			if c.wantErr {
-				ts.NotNil(err)
-				ts.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ts.Nil(err)
-				ts.IsType(&Terminal{}, m)
-				ts.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &Terminal{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
 }
 
-func (ts *terminalsServiceSuite) TestTerminalsService_List() {
+func TestTerminalsService_List(t *testing.T) {
+	setEnv()
+	defer unsetEnv()
+
 	type args struct {
 		ctx     context.Context
 		options *TerminalListOptions
@@ -136,8 +136,8 @@ func (ts *terminalsServiceSuite) TestTerminalsService_List() {
 			testdata.GetTerminalResponse,
 			noPre,
 			func(w http.ResponseWriter, r *http.Request) {
-				testHeader(ts.T(), r, AuthHeader, "Bearer token_X12b31ggg23")
-				testMethod(ts.T(), r, "GET")
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "GET")
 
 				if _, ok := r.Header[AuthHeader]; !ok {
 					w.WriteHeader(http.StatusUnauthorized)
@@ -187,23 +187,19 @@ func (ts *terminalsServiceSuite) TestTerminalsService_List() {
 		setup()
 		defer teardown()
 
-		ts.T().Run(c.name, func(t *testing.T) {
+		t.Run(c.name, func(t *testing.T) {
 			c.pre()
 			tMux.HandleFunc("/v2/terminals", c.handler)
 
 			res, m, err := tClient.Terminals.List(c.args.ctx, c.args.options)
 			if c.wantErr {
-				ts.NotNil(err)
-				ts.EqualError(err, c.err.Error())
+				assert.NotNil(t, err)
+				assert.EqualError(t, err, c.err.Error())
 			} else {
-				ts.Nil(err)
-				ts.IsType(&TerminalList{}, m)
-				ts.IsType(&http.Response{}, res.Response)
+				assert.Nil(t, err)
+				assert.IsType(t, &TerminalList{}, m)
+				assert.IsType(t, &http.Response{}, res.Response)
 			}
 		})
 	}
-}
-
-func TestTerminalService(t *testing.T) {
-	suite.Run(t, new(terminalsServiceSuite))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Removes the usage of `testify.Suite` from the codebase.

## Motivation and context

Using `testify` is ok however multiple community resources discourage the usage of the `Suite` resources.

After considering the tradeoffs, I decided to remove all the usages of `testify.Suite` from the library.

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

- [x] Unit tests added / updated
- [x] The tests run on docker (using `make test`)
- [ ] The required `test data` has been added / updated

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
