### PR TITLE
Fix documentation links and automate with lychee

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,24 @@
+name: "Check docs links"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - ".github/workflows/documentation-links.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/documentation-links.yml"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -17,18 +17,20 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1
-        with:
-          output: json
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621
 
-      # - name: Create Issue From File
-      #   if: env.lychee_exit_code != 0
-      #   uses: peter-evans/create-issue-from-file@v4
-      #   with:
-      #     title: Link Checker Report
-      #     content-filepath: ./lychee/out.md
-      #     labels: report, automated issue
+      - name: Create Issue From File
+        if: env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: |
+            report
+            automated-issue
+            help-wanted
+          assignees: VictorAvelar

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -22,3 +22,5 @@ jobs:
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v1
+        with:
+          output: json

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -24,3 +24,11 @@ jobs:
         uses: lycheeverse/lychee-action@v1
         with:
           output: json
+
+      # - name: Create Issue From File
+      #   if: env.lychee_exit_code != 0
+      #   uses: peter-evans/create-issue-from-file@v4
+      #   with:
+      #     title: Link Checker Report
+      #     content-filepath: ./lychee/out.md
+      #     labels: report, automated issue

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.X
+          go-version: 1.23.X
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
           version: latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        go: [1.20.x, 1.21.x, 1.22.x]
+        go: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
     name: Go ${{ matrix.go }} check
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200
         with:
           distribution: goreleaser

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ declared inside the `.github/workflows/main.yml` file.
 | 1.20.x  | :white_check_mark: |
 | 1.21.x  | :white_check_mark: |
 | 1.22.x  | :white_check_mark: |
+| 1.23.x  | :white_check_mark: |
 | master  | :x:                |
 
 ## Reporting a Vulnerability

--- a/docs/README.md
+++ b/docs/README.md
@@ -5124,7 +5124,7 @@ func (rs *RefundsService) CancelPaymentRefund(ctx context.Context, paymentID, re
 
 CancelPaymentRefund cancels a refund for a specific payment.
 
-See https://docs.mollie.com/reference/cancel-payment-refund
+See https://docs.mollie.com/reference/cancel-refund
 
 <a name="RefundsService.CreateOrderRefund"></a>
 ### func \(\*RefundsService\) [CreateOrderRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L238-L246>)
@@ -5146,7 +5146,7 @@ func (rs *RefundsService) CreatePaymentRefund(ctx context.Context, paymentID str
 
 Create a refund payment request.
 
-See https://docs.mollie.com/reference/create-payment-refund
+See https://docs.mollie.com/reference/create-refund
 
 <a name="RefundsService.GetPaymentRefund"></a>
 ### func \(\*RefundsService\) [GetPaymentRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L146-L154>)
@@ -5157,7 +5157,7 @@ func (rs *RefundsService) GetPaymentRefund(ctx context.Context, paymentID, refun
 
 GetPaymentRefund retrieves a specific refund for a specific payment.
 
-See: https://docs.mollie.com/reference/get-payment-refund
+See: https://docs.mollie.com/reference/get-refund
 
 <a name="RefundsService.List"></a>
 ### func \(\*RefundsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L126-L130>)
@@ -5168,7 +5168,7 @@ func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (r
 
 List retrieves all refunds.
 
-See https://docs.mollie.com/reference/list-refunds.
+See https://docs.mollie.com/reference/list-all-refunds.
 
 <a name="RefundsService.ListOrderRefunds"></a>
 ### func \(\*RefundsService\) [ListOrderRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L268-L276>)
@@ -5190,7 +5190,7 @@ func (rs *RefundsService) ListPaymentRefunds(ctx context.Context, paymentID stri
 
 ListPaymentRefunds retrieves all refunds for a specific payment.
 
-See: https://docs.mollie.com/reference/list-payment-refunds
+See: https://docs.mollie.com/reference/list-refunds
 
 <a name="Response"></a>
 ## type [Response](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mollie.go#L340-L343>)

--- a/docs/README.md
+++ b/docs/README.md
@@ -5405,7 +5405,7 @@ func (ss *SettlementsService) GetCaptures(ctx context.Context, settlement string
 
 GetCaptures retrieves all captures included in a settlement.
 
-See: https://docs.mollie.com/reference/list-settlement-captures
+See: https://docs.mollie.com/reference/get-settlement-captures
 
 <a name="SettlementsService.GetChargebacks"></a>
 ### func \(\*SettlementsService\) [GetChargebacks](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L185-L189>)
@@ -5416,7 +5416,7 @@ func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement str
 
 GetChargebacks retrieves all chargebacks included in a settlement.
 
-See: https://docs.mollie.com/reference/list-settlement-chargebacks
+See: https://docs.mollie.com/reference/get-settlement-chargebacks
 
 <a name="SettlementsService.GetRefunds"></a>
 ### func \(\*SettlementsService\) [GetRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L165-L169>)
@@ -5427,7 +5427,7 @@ func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string,
 
 GetRefunds retrieves all refunds included in a settlement.
 
-See: https://docs.mollie.com/reference/list-settlement-refunds
+See: https://docs.mollie.com/reference/get-settlement-refunds
 
 <a name="SettlementsService.List"></a>
 ### func \(\*SettlementsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L124-L128>)
@@ -5449,7 +5449,7 @@ func (ss *SettlementsService) ListPayments(ctx context.Context, settlement strin
 
 ListPayments retrieves all payments included in a settlement. This API is an alias of the List payments.
 
-See: https://docs.mollie.com/reference/list-settlement-payments
+See: https://docs.mollie.com/reference/get-settlement-payments
 
 <a name="SettlementsService.Next"></a>
 ### func \(\*SettlementsService\) [Next](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L109>)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4871,7 +4871,7 @@ func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID 
 
 DisableGiftCardIssuer deactivates the requested gift card issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/disable-gift-card-issuer
+See: https://docs.mollie.com/reference/disable-method-issuer
 
 <a name="ProfilesService.DisableGiftCardIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [DisableGiftCardIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L287-L290>)
@@ -4882,7 +4882,7 @@ func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, 
 
 DisableGiftCardIssuerForCurrent deactivates the specified issuer for the current profile when using API tokens.
 
-See: https://docs.mollie.com/reference/disable-gift-card-issuer
+See: https://docs.mollie.com/reference/disable-method-issuer
 
 <a name="ProfilesService.DisablePaymentMethod"></a>
 ### func \(\*ProfilesService\) [DisablePaymentMethod](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L213-L216>)
@@ -4902,7 +4902,7 @@ func (ps *ProfilesService) DisableVoucherIssuer(ctx context.Context, profileID s
 
 DisableVoucherIssuer deactivates the requested voucher issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/disable-voucher-issuer
+See: https://docs.mollie.com/reference/disable-method-issuer
 
 <a name="ProfilesService.DisableVoucherIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [DisableVoucherIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L362-L365>)
@@ -4922,7 +4922,7 @@ func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID s
 
 EnableGiftCardIssuer activates the requested gift card issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/enable-gift-card-issuer
+See: https://docs.mollie.com/reference/enable-method-issuer
 
 <a name="ProfilesService.EnableGiftCardIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [EnableGiftCardIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L266-L270>)
@@ -4933,7 +4933,7 @@ func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, i
 
 EnableGiftCardIssuerForCurrent activates the specified issuer for the current profile when using API tokens.
 
-See: https://docs.mollie.com/reference/enable-gift-card-issuer
+See: https://docs.mollie.com/reference/enable-method-issuer
 
 <a name="ProfilesService.EnablePaymentMethod"></a>
 ### func \(\*ProfilesService\) [EnablePaymentMethod](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L194-L198>)
@@ -4953,7 +4953,7 @@ func (ps *ProfilesService) EnableVoucherIssuer(ctx context.Context, profileID st
 
 EnableVoucherIssuer activates the requested voucher issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/enable-voucher-issuer
+See: https://docs.mollie.com/reference/enable-method-issuer
 
 <a name="ProfilesService.EnableVoucherIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [EnableVoucherIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L343-L347>)
@@ -5791,7 +5791,7 @@ func (ss *SubscriptionsService) ListPayments(ctx context.Context, customer, subs
 
 ListPayments retrieves all payments of a specific subscriptions of a customer
 
-See: https://docs.mollie.com/reference/list-subscriptions-payments
+See: https://docs.mollie.com/reference/list-subscription-payments
 
 <a name="SubscriptionsService.Update"></a>
 ### func \(\*SubscriptionsService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L160-L164>)

--- a/docs/README.md
+++ b/docs/README.md
@@ -746,7 +746,7 @@ BalancesService allows you to retrieve real\-time as well as historical informat
 
 Works with Organization access tokens and App access tokens.
 
-See: https://docs.mollie.com/reference/v2/balances-api/overview
+See: https://docs.mollie.com/reference/balances-api
 
 ```go
 type BalancesService service
@@ -761,7 +761,7 @@ func (bs *BalancesService) Get(ctx context.Context, balance string) (res *Respon
 
 GetBalance retrieves a balance by its id.
 
-See: https://docs.mollie.com/reference/v2/balances-api/get-balance
+See: https://docs.mollie.com/reference/get-balance
 
 <a name="BalancesService.GetPrimaryReport"></a>
 ### func \(\*BalancesService\) [GetPrimaryReport](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L268-L272>)
@@ -772,7 +772,7 @@ func (bs *BalancesService) GetPrimaryReport(ctx context.Context, options *Balanc
 
 GetPrimaryReport returns the report for the primary balance.
 
-See: https://docs.mollie.com/reference/v2/balances-api/get-primary-balance-report
+See: https://docs.mollie.com/reference/get-primary-balance-report
 
 <a name="BalancesService.GetPrimaryTransactionsList"></a>
 ### func \(\*BalancesService\) [GetPrimaryTransactionsList](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L296-L300>)
@@ -783,7 +783,7 @@ func (bs *BalancesService) GetPrimaryTransactionsList(ctx context.Context, optio
 
 GetPrimaryTransactionsList retrieves the list of movements \(transactions\) for the primary balance of the account.
 
-See: https://docs.mollie.com/reference/v2/balances-api/list-primary-balance-transactions
+See: https://docs.mollie.com/reference/list-primary-balance-transactions
 
 <a name="BalancesService.GetReport"></a>
 ### func \(\*BalancesService\) [GetReport](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L257-L261>)
@@ -794,7 +794,7 @@ func (bs *BalancesService) GetReport(ctx context.Context, balance string, option
 
 GetReport returns the balance report for the specified balance id.
 
-See: https://docs.mollie.com/reference/v2/balances-api/get-balance-report
+See: https://docs.mollie.com/reference/get-balance-report
 
 <a name="BalancesService.GetTransactionsList"></a>
 ### func \(\*BalancesService\) [GetTransactionsList](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L280-L288>)
@@ -805,7 +805,7 @@ func (bs *BalancesService) GetTransactionsList(ctx context.Context, balance stri
 
 GetTransactionsList retrieves a list of movements \(transactions\) for the specified balance.
 
-See: https://docs.mollie.com/reference/v2/balances-api/list-balance-transactions
+See: https://docs.mollie.com/reference/list-balance-transactions
 
 <a name="BalancesService.List"></a>
 ### func \(\*BalancesService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L246-L250>)
@@ -816,7 +816,7 @@ func (bs *BalancesService) List(ctx context.Context, options *ListBalancesOption
 
 List retrieves all the organization’s balances, including the primary balance, ordered from newest to oldest.
 
-See: https://docs.mollie.com/reference/v2/balances-api/list-balances
+See: https://docs.mollie.com/reference/list-balances
 
 <a name="BalancesService.Primary"></a>
 ### func \(\*BalancesService\) [Primary](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L236>)
@@ -827,7 +827,7 @@ func (bs *BalancesService) Primary(ctx context.Context) (res *Response, b *Balan
 
 Primary retrieves the primary balance. This is the balance of your account’s primary currency, where all payments are settled to by default.
 
-See: https://docs.mollie.com/reference/v2/balances-api/get-primary-balance
+See: https://docs.mollie.com/reference/get-primary-balance
 
 <a name="BaseError"></a>
 ## type [BaseError](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/errors.go#L13-L19>)
@@ -1077,7 +1077,7 @@ const (
 
 CaptureOptions describes the query params available to use when retrieving captures.
 
-See: https://docs.mollie.com/reference/v2/captures-api/get-capture#embedding-of-related-resources
+See: https://docs.mollie.com/reference/get-capture#embedding-of-related-resources
 
 ```go
 type CaptureOptions struct {
@@ -1137,7 +1137,7 @@ func (cs *CapturesService) Create(ctx context.Context, payment string, capture C
 
 Create creates a new capture for a payment.
 
-See: https://docs.mollie.com/reference/v2/captures-api/create-capture
+See: https://docs.mollie.com/reference/create-capture
 
 <a name="CapturesService.Get"></a>
 ### func \(\*CapturesService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/captures.go#L92-L96>)
@@ -1148,7 +1148,7 @@ func (cs *CapturesService) Get(ctx context.Context, payment, capture string, opt
 
 Get retrieves a single capture by its ID. Note the original payment’s ID is needed as well.
 
-See: https://docs.mollie.com/reference/v2/captures-api/get-capture
+See: https://docs.mollie.com/reference/get-capture
 
 <a name="CapturesService.List"></a>
 ### func \(\*CapturesService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/captures.go#L140-L144>)
@@ -1159,7 +1159,7 @@ func (cs *CapturesService) List(ctx context.Context, payment string, options *Ca
 
 List retrieves all captures for a certain payment.
 
-See: https://docs.mollie.com/reference/v2/captures-api/list-captures
+See: https://docs.mollie.com/reference/list-captures
 
 <a name="CardLabel"></a>
 ## type [CardLabel](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mandates.go#L68>)
@@ -1330,7 +1330,7 @@ func (cs *ChargebacksService) Get(ctx context.Context, payment, chargeback strin
 
 Get retrieves a single chargeback by its ID. Note the original payment’s ID is needed as well.
 
-See: https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
+See: https://docs.mollie.com/reference/get-chargeback
 
 <a name="ChargebacksService.List"></a>
 ### func \(\*ChargebacksService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/chargebacks.go#L98-L102>)
@@ -1341,7 +1341,7 @@ func (cs *ChargebacksService) List(ctx context.Context, options *ListChargebacks
 
 List retrieves a list of chargebacks associated with your account/organization.
 
-See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+See: https://docs.mollie.com/reference/list-chargebacks
 
 <a name="ChargebacksService.ListForPayment"></a>
 ### func \(\*ChargebacksService\) [ListForPayment](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/chargebacks.go#L109-L113>)
@@ -1352,7 +1352,7 @@ func (cs *ChargebacksService) ListForPayment(ctx context.Context, payment string
 
 ListForPayment retrieves a list of chargebacks associated with a single payment.
 
-See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+See: https://docs.mollie.com/reference/list-chargebacks
 
 <a name="Client"></a>
 ## type [Client](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mollie.go#L43-L75>)
@@ -1511,7 +1511,7 @@ func (cls *ClientLinksService) Create(ctx context.Context, cd CreateClientLink) 
 
 Create a client link based on the provided CreateClientLink values.
 
-See: https://docs.mollie.com/reference/v2/client-links-api/create-client-link
+See: https://docs.mollie.com/reference/create-client-link
 
 <a name="ClientLinksService.GetFinalClientLink"></a>
 ### func \(\*ClientLinksService\) [GetFinalClientLink](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/client_links.go#L78-L84>)
@@ -1540,7 +1540,7 @@ func (ps *ClientsService) Get(ctx context.Context, id string, opts *GetLinkedCli
 
 Get retrieves a single client, linked to your partner account, by its ID.
 
-See: https://docs.mollie.com/reference/v2/partners-api/get-client
+See: https://docs.mollie.com/reference/get-client
 
 <a name="ClientsService.List"></a>
 ### func \(\*ClientsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/clients.go#L53-L57>)
@@ -1551,7 +1551,7 @@ func (ps *ClientsService) List(ctx context.Context, opts *ListLinkedClientsOptio
 
 List retrieves all clients.
 
-See: https://docs.mollie.com/reference/v2/partners-api/list-clients
+See: https://docs.mollie.com/reference/list-clients
 
 <a name="Company"></a>
 ## type [Company](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/common_types.go#L52-L56>)
@@ -1891,7 +1891,7 @@ type CreateMandateAccessTokenFields struct {
 
 CreateMollieConnectPaymentFields describes the fields to be sent to the Mollie API when creating a new payment using Mollie Connect.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#mollie-connect-parameters
+See: https://docs.mollie.com/reference/create-payment#mollie-connect-parameters
 
 ```go
 type CreateMollieConnectPaymentFields struct {
@@ -1965,7 +1965,7 @@ CreatePayment describes the payload to be sent to the Mollie API when creating o
 
 Some fields are only valid for specific payment methods, and are documented in the Mollie API reference.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#payment-method-specific-parameters
+See: https://docs.mollie.com/reference/create-payment#payment-method-specific-parameters
 
 ```go
 type CreatePayment struct {
@@ -2014,7 +2014,7 @@ type CreatePayment struct {
 
 CreatePaymentAccessTokenFields describes the fields to be sent to the Mollie API when creating a new payment using an access token.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#access-token-parameters
+See: https://docs.mollie.com/reference/create-payment#access-token-parameters
 
 ```go
 type CreatePaymentAccessTokenFields struct {
@@ -2043,7 +2043,7 @@ type CreatePaymentRefund struct {
 
 CreatePreAuthorizedPaymentFields describes the fields to be sent to the Mollie API when creating a new pre\-authorized payment.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#parameters-for-pre-authorized-payments
+See: https://docs.mollie.com/reference/create-payment#parameters-for-pre-authorized-payments
 
 ```go
 type CreatePreAuthorizedPaymentFields struct {
@@ -2057,7 +2057,7 @@ type CreatePreAuthorizedPaymentFields struct {
 
 CreateRecurrentPaymentFields describes the fields to be sent to the Mollie API when creating a new recurrent payment.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#parameters-for-recurring-payments
+See: https://docs.mollie.com/reference/create-payment#parameters-for-recurring-payments
 
 ```go
 type CreateRecurrentPaymentFields struct {
@@ -2168,7 +2168,7 @@ func (cs *CustomersService) Create(ctx context.Context, c CreateCustomer) (res *
 
 Create creates a simple minimal representation of a customer in the Mollie API to use for the Mollie Checkout and Recurring features.
 
-See: https://docs.mollie.com/reference/v2/customers-api/create-customer
+See: https://docs.mollie.com/reference/create-customer
 
 <a name="CustomersService.CreatePayment"></a>
 ### func \(\*CustomersService\) [CreatePayment](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L189-L193>)
@@ -2179,7 +2179,7 @@ func (cs *CustomersService) CreatePayment(ctx context.Context, id string, p Crea
 
 CreatePayment creates a payment for the customer.
 
-See: https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
+See: https://docs.mollie.com/reference/create-customer-payment
 
 <a name="CustomersService.Delete"></a>
 ### func \(\*CustomersService\) [Delete](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L133>)
@@ -2192,7 +2192,7 @@ Delete a customer.
 
 All mandates and subscriptions created for this customer will be canceled as well.
 
-See: https://docs.mollie.com/reference/v2/customers-api/delete-customer
+See: https://docs.mollie.com/reference/delete-customer
 
 <a name="CustomersService.Get"></a>
 ### func \(\*CustomersService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L74>)
@@ -2203,7 +2203,7 @@ func (cs *CustomersService) Get(ctx context.Context, id string) (res *Response, 
 
 Get finds a customer by its ID.
 
-See: https://docs.mollie.com/reference/v2/customers-api/get-customer
+See: https://docs.mollie.com/reference/get-customer
 
 <a name="CustomersService.GetPayments"></a>
 ### func \(\*CustomersService\) [GetPayments](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L167-L171>)
@@ -2214,7 +2214,7 @@ func (cs *CustomersService) GetPayments(ctx context.Context, id string, options 
 
 GetPayments retrieves all payments linked to the customer.
 
-See: https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+See: https://docs.mollie.com/reference/list-customer-payments
 
 <a name="CustomersService.List"></a>
 ### func \(\*CustomersService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L147-L151>)
@@ -2225,7 +2225,7 @@ func (cs *CustomersService) List(ctx context.Context, options *ListCustomersOpti
 
 List retrieves all customers created.
 
-See: https://docs.mollie.com/reference/v2/customers-api/list-customers
+See: https://docs.mollie.com/reference/list-customers
 
 <a name="CustomersService.Update"></a>
 ### func \(\*CustomersService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/customers.go#L109-L113>)
@@ -2236,7 +2236,7 @@ func (cs *CustomersService) Update(ctx context.Context, id string, c UpdateCusto
 
 Update an existing customer.
 
-See: https://docs.mollie.com/reference/v2/customers-api/update-customer
+See: https://docs.mollie.com/reference/update-customer
 
 <a name="EligibilityReasons"></a>
 ## type [EligibilityReasons](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_details.go#L35>)
@@ -3056,7 +3056,7 @@ Create a mandate for a specific customer.
 
 Mandates allow you to charge a customer’s credit card or bank account recurrently.
 
-See: https://docs.mollie.com/reference/v2/mandates-api/create-mandate
+See: https://docs.mollie.com/reference/create-mandate
 
 <a name="MandatesService.Get"></a>
 ### func \(\*MandatesService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mandates.go#L149>)
@@ -3067,7 +3067,7 @@ func (ms *MandatesService) Get(ctx context.Context, customer, mandate string) (r
 
 Get retrieves a mandate by its ID and its customer’s ID. The mandate will either contain IBAN or credit card details, depending on the type of mandate.
 
-See: https://docs.mollie.com/reference/v2/mandates-api/get-mandate
+See: https://docs.mollie.com/reference/get-mandate
 
 <a name="MandatesService.List"></a>
 ### func \(\*MandatesService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mandates.go#L185-L189>)
@@ -3078,7 +3078,7 @@ func (ms *MandatesService) List(ctx context.Context, customer string, options *L
 
 List retrieves all mandates for the given customerId, ordered from newest to oldest.
 
-See: https://docs.mollie.com/reference/v2/mandates-api/list-mandates
+See: https://docs.mollie.com/reference/list-mandates
 
 <a name="MandatesService.Revoke"></a>
 ### func \(\*MandatesService\) [Revoke](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mandates.go#L170>)
@@ -3091,7 +3091,7 @@ Revoke a customer’s mandate.
 
 You will no longer be able to charge the consumer’s bank account or credit card with this mandate and all connected subscriptions will be canceled.
 
-See: https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
+See: https://docs.mollie.com/reference/revoke-mandate
 
 <a name="MethodsLinks"></a>
 ## type [MethodsLinks](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_methods.go#L38-L41>)
@@ -3226,7 +3226,7 @@ func (os *OnboardingService) GetOnboardingStatus(ctx context.Context) (res *Resp
 
 GetOnboardingStatus gets the status of onboarding of the authenticated organization.
 
-See: https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
+See: https://docs.mollie.com/reference/get-onboarding-status
 
 <a name="OnboardingService.SubmitOnboardingData"></a>
 ### func \(\*OnboardingService\) [SubmitOnboardingData](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/onboarding.go#L98>)
@@ -3239,7 +3239,7 @@ SubmitOnboardingData sends data that will be prefilled in the merchant’s onboa
 
 This endpoint has been deprecated. It will be supported for the foreseeable future, but new implementations should use the Create client link endpoint to create new clients and submit their organization’s details in one go.
 
-See: https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data
+See: https://docs.mollie.com/reference/submit-onboarding-data
 
 <a name="OnboardingStatus"></a>
 ## type [OnboardingStatus](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/onboarding.go#L12>)
@@ -3635,7 +3635,7 @@ func (ors *OrdersService) Cancel(ctx context.Context, orderID string) (res *Resp
 
 Cancel try to cancel the order that fulfill certain requirements.
 
-See https://docs.mollie.com/reference/v2/orders-api/cancel-order
+See https://docs.mollie.com/reference/cancel-order
 
 <a name="OrdersService.CancelOrderLines"></a>
 ### func \(\*OrdersService\) [CancelOrderLines](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L465-L468>)
@@ -3646,7 +3646,7 @@ func (ors *OrdersService) CancelOrderLines(ctx context.Context, orderID string, 
 
 CancelOrderLines can be used to cancel one or more order lines that were previously authorized using a pay after delivery payment method. Use the Cancel Order API if you want to cancel the entire order or the remainder of the order.
 
-See https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
+See https://docs.mollie.com/reference/cancel-order-lines
 
 <a name="OrdersService.Create"></a>
 ### func \(\*OrdersService\) [Create](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L349-L353>)
@@ -3657,7 +3657,7 @@ func (ors *OrdersService) Create(ctx context.Context, ord CreateOrder, opts *Ord
 
 Create an order will automatically create the required payment to allow your customer to pay for the order.
 
-See https://docs.mollie.com/reference/v2/orders-api/create-order
+See https://docs.mollie.com/reference/create-order
 
 <a name="OrdersService.CreateOrderPayment"></a>
 ### func \(\*OrdersService\) [CreateOrderPayment](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L483-L487>)
@@ -3668,7 +3668,7 @@ func (ors *OrdersService) CreateOrderPayment(ctx context.Context, orderID string
 
 CreateOrderPayment can only be created while the status of the order is created, and when the status of the existing payment is either expired, canceled or failed.
 
-See https://docs.mollie.com/reference/v2/orders-api/create-order-payment
+See https://docs.mollie.com/reference/create-order-payment
 
 <a name="OrdersService.CreateOrderRefund"></a>
 ### func \(\*OrdersService\) [CreateOrderRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L505-L509>)
@@ -3679,7 +3679,7 @@ func (ors *OrdersService) CreateOrderRefund(ctx context.Context, orderID string,
 
 CreateOrderRefund using the Orders API, refunds should be made against the order.
 
-See https://docs.mollie.com/reference/v2/orders-api/create-order-refund
+See https://docs.mollie.com/reference/create-order-refund
 
 <a name="OrdersService.Get"></a>
 ### func \(\*OrdersService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L329-L333>)
@@ -3690,7 +3690,7 @@ func (ors *OrdersService) Get(ctx context.Context, orID string, opts *OrderOptio
 
 Get retrieve a single order by its ID.
 
-See https://docs.mollie.com/reference/v2/orders-api/get-order
+See https://docs.mollie.com/reference/get-order
 
 <a name="OrdersService.List"></a>
 ### func \(\*OrdersService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L413-L417>)
@@ -3701,7 +3701,7 @@ func (ors *OrdersService) List(ctx context.Context, opts *ListOrdersOptions) (re
 
 List is to retrieve all orders.
 
-See https://docs.mollie.com/reference/v2/orders-api/list-orders
+See https://docs.mollie.com/reference/list-orders
 
 <a name="OrdersService.ListOrderRefunds"></a>
 ### func \(\*OrdersService\) [ListOrderRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L527-L531>)
@@ -3712,7 +3712,7 @@ func (ors *OrdersService) ListOrderRefunds(ctx context.Context, orderID string, 
 
 ListOrderRefunds retrieve all order refunds.
 
-See https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
+See https://docs.mollie.com/reference/list-order-refunds
 
 <a name="OrdersService.ManageOrderLines"></a>
 ### func \(\*OrdersService\) [ManageOrderLines](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L549-L553>)
@@ -3723,7 +3723,7 @@ func (ors *OrdersService) ManageOrderLines(ctx context.Context, orderID string, 
 
 ManageOrderLines allows to update, cancel, or add one or more order lines.
 
-See: https://docs.mollie.com/reference/v2/orders-api/manage-order-lines
+See: https://docs.mollie.com/reference/manage-order-lines
 
 <a name="OrdersService.Update"></a>
 ### func \(\*OrdersService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L373-L377>)
@@ -3734,7 +3734,7 @@ func (ors *OrdersService) Update(ctx context.Context, orderID string, ord Update
 
 Update is used to update the billing and/or shipping address of an order.
 
-See https://docs.mollie.com/reference/v2/orders-api/update-order
+See https://docs.mollie.com/reference/update-order
 
 <a name="OrdersService.UpdateOrderLine"></a>
 ### func \(\*OrdersService\) [UpdateOrderLine](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/orders.go#L433-L441>)
@@ -3745,7 +3745,7 @@ func (ors *OrdersService) UpdateOrderLine(ctx context.Context, orderID string, o
 
 UpdateOrderLine can be used to update an order line.
 
-See https://docs.mollie.com/reference/v2/orders-api/update-orderline
+See https://docs.mollie.com/reference/update-orderline
 
 <a name="Organization"></a>
 ## type [Organization](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/organizations.go#L11-L22>)
@@ -3853,7 +3853,7 @@ func (os *OrganizationsService) GetPartnerStatus(ctx context.Context) (res *Resp
 
 GetPartnerStatus retrieves details about the partner status of the currently authenticated organization.
 
-See: https://docs.mollie.com/reference/v2/organizations-api/get-partner
+See: https://docs.mollie.com/reference/get-partner
 
 <a name="Owner"></a>
 ## type [Owner](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/common_types.go#L363-L368>)
@@ -4090,7 +4090,7 @@ type PaymentLines struct {
 
 PaymentLink is a resource that can be shared with your customers and will redirect them to them the payment page where they can complete the payment.
 
-See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+See: https://docs.mollie.com/reference/get-payment-link
 
 ```go
 type PaymentLink struct {
@@ -4115,7 +4115,7 @@ type PaymentLink struct {
 
 PaymentLinkLinks describes all the possible links returned with a payment link struct.
 
-See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+See: https://docs.mollie.com/reference/get-payment-link
 
 ```go
 type PaymentLinkLinks struct {
@@ -4198,7 +4198,7 @@ func (pls *PaymentLinksService) Create(ctx context.Context, p PaymentLink, opts 
 
 Create generates payment links that by default, unlike regular payments, do not expire.
 
-See: https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link
+See: https://docs.mollie.com/reference/create-payment-link
 
 <a name="PaymentLinksService.Delete"></a>
 ### func \(\*PaymentLinksService\) [Delete](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_links.go#L151>)
@@ -4220,7 +4220,7 @@ func (pls *PaymentLinksService) Get(ctx context.Context, id string) (res *Respon
 
 Get retrieves a single payment link object by its id/token.
 
-See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+See: https://docs.mollie.com/reference/get-payment-link
 
 <a name="PaymentLinksService.List"></a>
 ### func \(\*PaymentLinksService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_links.go#L111-L115>)
@@ -4231,7 +4231,7 @@ func (pls *PaymentLinksService) List(ctx context.Context, opts *PaymentLinkOptio
 
 List retrieves all payments links created with the current website profile, ordered from newest to oldest.
 
-See: https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
+See: https://docs.mollie.com/reference/list-payment-links
 
 <a name="PaymentLinksService.Update"></a>
 ### func \(\*PaymentLinksService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_links.go#L131-L135>)
@@ -4410,7 +4410,7 @@ func (ms *PaymentMethodsService) All(ctx context.Context, options *ListPaymentMe
 
 All retrieves all the payment methods enabled for your account/organization.
 
-See: https://docs.mollie.com/reference/v2/methods-api/list-all-methods
+See: https://docs.mollie.com/reference/list-all-methods
 
 <a name="PaymentMethodsService.Get"></a>
 ### func \(\*PaymentMethodsService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_methods.go#L102-L106>)
@@ -4421,7 +4421,7 @@ func (ms *PaymentMethodsService) Get(ctx context.Context, id PaymentMethod, opti
 
 Get returns information about the payment method specified by id, it also receives a pointer to the method options containing applicable query string parameters.
 
-See: https://docs.mollie.com/reference/v2/methods-api/get-method
+See: https://docs.mollie.com/reference/get-method
 
 <a name="PaymentMethodsService.List"></a>
 ### func \(\*PaymentMethodsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payment_methods.go#L137-L141>)
@@ -4434,14 +4434,14 @@ List retrieves all enabled payment methods.
 
 The results are not paginated.
 
-See: https://docs.mollie.com/reference/v2/methods-api/list-methods
+See: https://docs.mollie.com/reference/list-methods
 
 <a name="PaymentOptions"></a>
 ## type [PaymentOptions](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payments.go#L289-L292>)
 
 PaymentOptions describes payments endpoint valid query string parameters.
 
-See: https://docs.mollie.com/reference/v2/payments-api/get-payment
+See: https://docs.mollie.com/reference/get-payment
 
 ```go
 type PaymentOptions struct {
@@ -4515,7 +4515,7 @@ func (ps *PaymentsService) Cancel(ctx context.Context, id string) (res *Response
 
 Cancel removes a payment \(if possible\) from your Mollie account.
 
-See: https://docs.mollie.com/reference/v2/payments-api/cancel-payment
+See: https://docs.mollie.com/reference/cancel-payment
 
 <a name="PaymentsService.Create"></a>
 ### func \(\*PaymentsService\) [Create](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payments.go#L327-L331>)
@@ -4526,7 +4526,7 @@ func (ps *PaymentsService) Create(ctx context.Context, p CreatePayment, opts *Pa
 
 Create stores a new payment object attached to your Mollie account.
 
-See: https://docs.mollie.com/reference/v2/payments-api/create-payment#
+See: https://docs.mollie.com/reference/create-payment#
 
 <a name="PaymentsService.Get"></a>
 ### func \(\*PaymentsService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payments.go#L307-L311>)
@@ -4546,7 +4546,7 @@ func (ps *PaymentsService) List(ctx context.Context, opts *ListPaymentsOptions) 
 
 List retrieves a list of payments associated with your account/organization.
 
-See: https://docs.mollie.com/reference/v2/payments-api/list-payments
+See: https://docs.mollie.com/reference/list-payments
 
 <a name="PaymentsService.Update"></a>
 ### func \(\*PaymentsService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/payments.go#L367-L371>)
@@ -4557,7 +4557,7 @@ func (ps *PaymentsService) Update(ctx context.Context, id string, up UpdatePayme
 
 Update can be used to update some details of a created payment.
 
-See: https://docs.mollie.com/reference/v2/payments-api/update-payment
+See: https://docs.mollie.com/reference/update-payment
 
 <a name="Permission"></a>
 ## type [Permission](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/permissions.go#L45-L51>)
@@ -4662,7 +4662,7 @@ func (ps *PermissionsService) Get(ctx context.Context, id PermissionGrant) (res 
 
 Get returns a permission by its id.
 
-See: https://docs.mollie.com/reference/v2/permissions-api/get-permission
+See: https://docs.mollie.com/reference/get-permission
 
 <a name="PermissionsService.List"></a>
 ### func \(\*PermissionsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/permissions.go#L93>)
@@ -4673,7 +4673,7 @@ func (ps *PermissionsService) List(ctx context.Context) (res *Response, pl *Perm
 
 List retrieves all permissions available with the current app access token. The list is not paginated.
 
-See: https://docs.mollie.com/reference/v2/permissions-api/list-permissions
+See: https://docs.mollie.com/reference/list-permissions
 
 <a name="PhoneNumber"></a>
 ## type [PhoneNumber](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/common_types.go#L118>)
@@ -4871,7 +4871,7 @@ func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID 
 
 DisableGiftCardIssuer deactivates the requested gift card issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+See: https://docs.mollie.com/reference/disable-gift-card-issuer
 
 <a name="ProfilesService.DisableGiftCardIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [DisableGiftCardIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L287-L290>)
@@ -4882,7 +4882,7 @@ func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, 
 
 DisableGiftCardIssuerForCurrent deactivates the specified issuer for the current profile when using API tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+See: https://docs.mollie.com/reference/disable-gift-card-issuer
 
 <a name="ProfilesService.DisablePaymentMethod"></a>
 ### func \(\*ProfilesService\) [DisablePaymentMethod](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L213-L216>)
@@ -4902,7 +4902,7 @@ func (ps *ProfilesService) DisableVoucherIssuer(ctx context.Context, profileID s
 
 DisableVoucherIssuer deactivates the requested voucher issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/disable-voucher-issuer
+See: https://docs.mollie.com/reference/disable-voucher-issuer
 
 <a name="ProfilesService.DisableVoucherIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [DisableVoucherIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L362-L365>)
@@ -4922,7 +4922,7 @@ func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID s
 
 EnableGiftCardIssuer activates the requested gift card issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+See: https://docs.mollie.com/reference/enable-gift-card-issuer
 
 <a name="ProfilesService.EnableGiftCardIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [EnableGiftCardIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L266-L270>)
@@ -4933,7 +4933,7 @@ func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, i
 
 EnableGiftCardIssuerForCurrent activates the specified issuer for the current profile when using API tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+See: https://docs.mollie.com/reference/enable-gift-card-issuer
 
 <a name="ProfilesService.EnablePaymentMethod"></a>
 ### func \(\*ProfilesService\) [EnablePaymentMethod](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L194-L198>)
@@ -4953,7 +4953,7 @@ func (ps *ProfilesService) EnableVoucherIssuer(ctx context.Context, profileID st
 
 EnableVoucherIssuer activates the requested voucher issuer for the provided profile id when using Organization tokens or App Access tokens.
 
-See: https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer
+See: https://docs.mollie.com/reference/enable-voucher-issuer
 
 <a name="ProfilesService.EnableVoucherIssuerForCurrent"></a>
 ### func \(\*ProfilesService\) [EnableVoucherIssuerForCurrent](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/profiles.go#L343-L347>)
@@ -5124,7 +5124,7 @@ func (rs *RefundsService) CancelPaymentRefund(ctx context.Context, paymentID, re
 
 CancelPaymentRefund cancels a refund for a specific payment.
 
-See https://docs.mollie.com/reference/v2/refunds-api/cancel-payment-refund
+See https://docs.mollie.com/reference/cancel-payment-refund
 
 <a name="RefundsService.CreateOrderRefund"></a>
 ### func \(\*RefundsService\) [CreateOrderRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L238-L246>)
@@ -5135,7 +5135,7 @@ func (rs *RefundsService) CreateOrderRefund(ctx context.Context, orderID string,
 
 CreateOrderRefund creates a refund for a specific order.
 
-See https://docs.mollie.com/reference/v2/refunds-api/create-order-refund
+See https://docs.mollie.com/reference/create-order-refund
 
 <a name="RefundsService.CreatePaymentRefund"></a>
 ### func \(\*RefundsService\) [CreatePaymentRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L198-L207>)
@@ -5146,7 +5146,7 @@ func (rs *RefundsService) CreatePaymentRefund(ctx context.Context, paymentID str
 
 Create a refund payment request.
 
-See https://docs.mollie.com/reference/v2/refunds-api/create-payment-refund
+See https://docs.mollie.com/reference/create-payment-refund
 
 <a name="RefundsService.GetPaymentRefund"></a>
 ### func \(\*RefundsService\) [GetPaymentRefund](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L146-L154>)
@@ -5157,7 +5157,7 @@ func (rs *RefundsService) GetPaymentRefund(ctx context.Context, paymentID, refun
 
 GetPaymentRefund retrieves a specific refund for a specific payment.
 
-See: https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund
+See: https://docs.mollie.com/reference/get-payment-refund
 
 <a name="RefundsService.List"></a>
 ### func \(\*RefundsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L126-L130>)
@@ -5168,7 +5168,7 @@ func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (r
 
 List retrieves all refunds.
 
-See https://docs.mollie.com/reference/v2/refunds-api/list-refunds.
+See https://docs.mollie.com/reference/list-refunds.
 
 <a name="RefundsService.ListOrderRefunds"></a>
 ### func \(\*RefundsService\) [ListOrderRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L268-L276>)
@@ -5179,7 +5179,7 @@ func (rs *RefundsService) ListOrderRefunds(ctx context.Context, orderID string, 
 
 ListOrderRefunds retrieves all refunds for a specific order.
 
-See https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
+See https://docs.mollie.com/reference/list-order-refunds
 
 <a name="RefundsService.ListPaymentRefunds"></a>
 ### func \(\*RefundsService\) [ListPaymentRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/refunds.go#L172-L180>)
@@ -5190,7 +5190,7 @@ func (rs *RefundsService) ListPaymentRefunds(ctx context.Context, paymentID stri
 
 ListPaymentRefunds retrieves all refunds for a specific payment.
 
-See: https://docs.mollie.com/reference/v2/refunds-api/list-payment-refunds
+See: https://docs.mollie.com/reference/list-payment-refunds
 
 <a name="Response"></a>
 ## type [Response](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/mollie.go#L340-L343>)
@@ -5394,7 +5394,7 @@ func (ss *SettlementsService) Get(ctx context.Context, settlement string) (res *
 
 Get returns a settlement by its id or the bank reference id
 
-See: https://docs.mollie.com/reference/v2/settlements-api/get-settlement
+See: https://docs.mollie.com/reference/get-settlement
 
 <a name="SettlementsService.GetCaptures"></a>
 ### func \(\*SettlementsService\) [GetCaptures](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L205-L209>)
@@ -5405,7 +5405,7 @@ func (ss *SettlementsService) GetCaptures(ctx context.Context, settlement string
 
 GetCaptures retrieves all captures included in a settlement.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+See: https://docs.mollie.com/reference/list-settlement-captures
 
 <a name="SettlementsService.GetChargebacks"></a>
 ### func \(\*SettlementsService\) [GetChargebacks](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L185-L189>)
@@ -5416,7 +5416,7 @@ func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement str
 
 GetChargebacks retrieves all chargebacks included in a settlement.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+See: https://docs.mollie.com/reference/list-settlement-chargebacks
 
 <a name="SettlementsService.GetRefunds"></a>
 ### func \(\*SettlementsService\) [GetRefunds](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L165-L169>)
@@ -5427,7 +5427,7 @@ func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string,
 
 GetRefunds retrieves all refunds included in a settlement.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
+See: https://docs.mollie.com/reference/list-settlement-refunds
 
 <a name="SettlementsService.List"></a>
 ### func \(\*SettlementsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L124-L128>)
@@ -5438,7 +5438,7 @@ func (ss *SettlementsService) List(ctx context.Context, slo *ListSettlementsOpti
 
 List retrieves all settlements, ordered from new to old
 
-See: https://docs.mollie.com/reference/v2/settlements-api/list-settlements
+See: https://docs.mollie.com/reference/list-settlements
 
 <a name="SettlementsService.ListPayments"></a>
 ### func \(\*SettlementsService\) [ListPayments](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L145-L149>)
@@ -5449,7 +5449,7 @@ func (ss *SettlementsService) ListPayments(ctx context.Context, settlement strin
 
 ListPayments retrieves all payments included in a settlement. This API is an alias of the List payments.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+See: https://docs.mollie.com/reference/list-settlement-payments
 
 <a name="SettlementsService.Next"></a>
 ### func \(\*SettlementsService\) [Next](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L109>)
@@ -5460,7 +5460,7 @@ func (ss *SettlementsService) Next(ctx context.Context) (res *Response, s *Settl
 
 Next retrieves the details of the current settlement that has not yet been paid out.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement
+See: https://docs.mollie.com/reference/get-next-settlement
 
 <a name="SettlementsService.Open"></a>
 ### func \(\*SettlementsService\) [Open](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/settlements.go#L117>)
@@ -5471,7 +5471,7 @@ func (ss *SettlementsService) Open(ctx context.Context) (res *Response, s *Settl
 
 Open retrieves the details of the open balance of the organization. This will return a settlement object representing your organization’s balance.
 
-See: https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement
+See: https://docs.mollie.com/reference/get-open-settlement
 
 <a name="Shipment"></a>
 ## type [Shipment](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/shipments.go#L25-L34>)
@@ -5561,7 +5561,7 @@ func (ss *ShipmentsService) Create(ctx context.Context, order string, cs CreateS
 
 Create can be used to ship order lines.
 
-See: https://docs.mollie.com/reference/v2/shipments-api/create-shipment
+See: https://docs.mollie.com/reference/create-shipment
 
 <a name="ShipmentsService.Get"></a>
 ### func \(\*ShipmentsService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/shipments.go#L72-L76>)
@@ -5572,7 +5572,7 @@ func (ss *ShipmentsService) Get(ctx context.Context, order string, shipment stri
 
 Get retrieves a single shipment and the order lines shipped by a shipment’s ID.
 
-See: https://docs.mollie.com/reference/v2/shipments-api/get-shipment#
+See: https://docs.mollie.com/reference/get-shipment#
 
 <a name="ShipmentsService.List"></a>
 ### func \(\*ShipmentsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/shipments.go#L120>)
@@ -5583,7 +5583,7 @@ func (ss *ShipmentsService) List(ctx context.Context, order string) (res *Respon
 
 List retrieves all shipments for an order.
 
-See: https://docs.mollie.com/reference/v2/shipments-api/list-shipments
+See: https://docs.mollie.com/reference/list-shipments
 
 <a name="ShipmentsService.Update"></a>
 ### func \(\*ShipmentsService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/shipments.go#L138-L142>)
@@ -5594,7 +5594,7 @@ func (ss *ShipmentsService) Update(ctx context.Context, order string, shipment s
 
 Update can be used to update the tracking information of a shipment
 
-See: https://docs.mollie.com/reference/v2/shipments-api/update-shipment
+See: https://docs.mollie.com/reference/update-shipment
 
 <a name="ShortDate"></a>
 ## type [ShortDate](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/common_types.go#L59-L61>)
@@ -5736,7 +5736,7 @@ func (ss *SubscriptionsService) All(ctx context.Context, opts *ListSubscriptions
 
 All retrieves all subscriptions, ordered from newest to oldest. By using an API key all the subscriptions created with the current website profile will be returned. In the case of an OAuth Access Token relies the website profile on the profileId field
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
+See: https://docs.mollie.com/reference/list-all-subscriptions
 
 <a name="SubscriptionsService.Cancel"></a>
 ### func \(\*SubscriptionsService\) [Cancel](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L182-L186>)
@@ -5747,7 +5747,7 @@ func (ss *SubscriptionsService) Cancel(ctx context.Context, customer, subscripti
 
 Cancel cancels a subscription.
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
+See: https://docs.mollie.com/reference/cancel-subscription
 
 <a name="SubscriptionsService.Create"></a>
 ### func \(\*SubscriptionsService\) [Create](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L134-L138>)
@@ -5758,7 +5758,7 @@ func (ss *SubscriptionsService) Create(ctx context.Context, customer string, sc 
 
 Create stores a new subscription for a given customer
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
+See: https://docs.mollie.com/reference/create-subscription
 
 <a name="SubscriptionsService.Get"></a>
 ### func \(\*SubscriptionsService\) [Get](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L112-L116>)
@@ -5769,7 +5769,7 @@ func (ss *SubscriptionsService) Get(ctx context.Context, customer, subscription 
 
 Get retrieves a customer's subscription
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
+See: https://docs.mollie.com/reference/get-subscription
 
 <a name="SubscriptionsService.List"></a>
 ### func \(\*SubscriptionsService\) [List](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L228-L232>)
@@ -5780,7 +5780,7 @@ func (ss *SubscriptionsService) List(ctx context.Context, customer string, opts 
 
 List retrieves all subscriptions of a customer
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
+See: https://docs.mollie.com/reference/list-subscriptions
 
 <a name="SubscriptionsService.ListPayments"></a>
 ### func \(\*SubscriptionsService\) [ListPayments](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L250-L258>)
@@ -5791,7 +5791,7 @@ func (ss *SubscriptionsService) ListPayments(ctx context.Context, customer, subs
 
 ListPayments retrieves all payments of a specific subscriptions of a customer
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+See: https://docs.mollie.com/reference/list-subscriptions-payments
 
 <a name="SubscriptionsService.Update"></a>
 ### func \(\*SubscriptionsService\) [Update](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/subscriptions.go#L160-L164>)
@@ -5802,7 +5802,7 @@ func (ss *SubscriptionsService) Update(ctx context.Context, customer, subscripti
 
 Update changes fields on a subscription object
 
-See: https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
+See: https://docs.mollie.com/reference/update-subscription
 
 <a name="Subtotal"></a>
 ## type [Subtotal](<https://github.com/VictorAvelar/mollie-api-go/blob/master/mollie/balances.go#L103-L108>)
@@ -6043,7 +6043,7 @@ type UpdateOrderLine struct {
 
 UpdatePayment describes the payload to be sent to the Mollie API when updating a payment.
 
-See: https://docs.mollie.com/reference/v2/payments-api/update-payment See: https://docs.mollie.com/reference/v2/payments-api/update-payment#payment-method-specific-parameters
+See: https://docs.mollie.com/reference/update-payment See: https://docs.mollie.com/reference/update-payment#payment-method-specific-parameters
 
 ```go
 type UpdatePayment struct {
@@ -6236,6 +6236,6 @@ func (ms *WalletsService) ApplePaymentSession(ctx context.Context, asr *ApplePay
 
 ApplePaymentSession returns an Apple Payment Session object valid for one transaction.
 
-See: https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session
+See: https://docs.mollie.com/reference/request-apple-pay-payment-session
 
 Generated by [gomarkdoc](<https://github.com/princjef/gomarkdoc>)

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+exclude_path = ["testdata", ".github", ".devcontainer", "wiki"]
+exclude = ['^https://github\.com']
+cache = true
+max_redirects = 3
+require_https = true
+timeout = 10

--- a/lychee.toml
+++ b/lychee.toml
@@ -5,3 +5,5 @@ max_redirects = 3
 require_https = true
 timeout = 10
 retry_wait_time = 15
+verbose = "error"
+no_progress = true

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,4 @@
-exclude_path = ["testdata", ".github", ".devcontainer", "wiki"]
+exclude_path = [".github", ".devcontainer", "wiki"]
 exclude = ['^https://github\.com']
 cache = true
 max_redirects = 3

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,6 +1,7 @@
-exclude_path = [".github", ".devcontainer", "wiki"]
+exclude_path = [".github", ".devcontainer", "wiki", "mollie", "testdata"]
 exclude = ['^https://github\.com']
 cache = true
 max_redirects = 3
 require_https = true
 timeout = 10
+retry_wait_time = 15

--- a/mollie/balances.go
+++ b/mollie/balances.go
@@ -219,12 +219,12 @@ type ListBalanceTransactionsOptions struct {
 //
 // Works with Organization access tokens and App access tokens.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/overview
+// See: https://docs.mollie.com/reference/balances-api
 type BalancesService service
 
 // GetBalance retrieves a balance by its id.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/get-balance
+// See: https://docs.mollie.com/reference/get-balance
 func (bs *BalancesService) Get(ctx context.Context, balance string) (res *Response, b *Balance, err error) {
 	return bs.get(ctx, balance)
 }
@@ -232,7 +232,7 @@ func (bs *BalancesService) Get(ctx context.Context, balance string) (res *Respon
 // Primary retrieves the primary balance. This is the balance of your account’s
 // primary currency, where all payments are settled to by default.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/get-primary-balance
+// See: https://docs.mollie.com/reference/get-primary-balance
 func (bs *BalancesService) Primary(ctx context.Context) (res *Response, b *Balance, err error) {
 	const id = "primary"
 
@@ -242,7 +242,7 @@ func (bs *BalancesService) Primary(ctx context.Context) (res *Response, b *Balan
 // List retrieves all the organization’s balances, including the primary
 // balance, ordered from newest to oldest.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/list-balances
+// See: https://docs.mollie.com/reference/list-balances
 func (bs *BalancesService) List(ctx context.Context, options *ListBalancesOptions) (
 	res *Response,
 	bl *BalancesList,
@@ -253,7 +253,7 @@ func (bs *BalancesService) List(ctx context.Context, options *ListBalancesOption
 
 // GetReport returns the balance report for the specified balance id.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/get-balance-report
+// See: https://docs.mollie.com/reference/get-balance-report
 func (bs *BalancesService) GetReport(ctx context.Context, balance string, options *BalanceReportOptions) (
 	res *Response,
 	br *BalanceReport,
@@ -264,7 +264,7 @@ func (bs *BalancesService) GetReport(ctx context.Context, balance string, option
 
 // GetPrimaryReport returns the report for the primary balance.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/get-primary-balance-report
+// See: https://docs.mollie.com/reference/get-primary-balance-report
 func (bs *BalancesService) GetPrimaryReport(ctx context.Context, options *BalanceReportOptions) (
 	res *Response,
 	br *BalanceReport,
@@ -276,7 +276,7 @@ func (bs *BalancesService) GetPrimaryReport(ctx context.Context, options *Balanc
 // GetTransactionsList retrieves a list of movements (transactions) for the
 // specified balance.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/list-balance-transactions
+// See: https://docs.mollie.com/reference/list-balance-transactions
 func (bs *BalancesService) GetTransactionsList(
 	ctx context.Context,
 	balance string,
@@ -292,7 +292,7 @@ func (bs *BalancesService) GetTransactionsList(
 // GetPrimaryTransactionsList retrieves the list of movements (transactions) for the
 // primary balance of the account.
 //
-// See: https://docs.mollie.com/reference/v2/balances-api/list-primary-balance-transactions
+// See: https://docs.mollie.com/reference/list-primary-balance-transactions
 func (bs *BalancesService) GetPrimaryTransactionsList(ctx context.Context, options *ListBalanceTransactionsOptions) (
 	res *Response,
 	btl *BalanceTransactionsList,

--- a/mollie/captures.go
+++ b/mollie/captures.go
@@ -68,7 +68,7 @@ type CaptureLinks struct {
 
 // CaptureOptions describes the query params available to use when retrieving captures.
 //
-// See: https://docs.mollie.com/reference/v2/captures-api/get-capture#embedding-of-related-resources
+// See: https://docs.mollie.com/reference/get-capture#embedding-of-related-resources
 type CaptureOptions struct {
 	Embed []EmbedValue `url:"embed,omitempty"`
 }
@@ -88,7 +88,7 @@ type CapturesService service
 // Get retrieves a single capture by its ID.
 // Note the original payment’s ID is needed as well.
 //
-// See: https://docs.mollie.com/reference/v2/captures-api/get-capture
+// See: https://docs.mollie.com/reference/get-capture
 func (cs *CapturesService) Get(ctx context.Context, payment, capture string, options *CaptureOptions) (
 	res *Response,
 	c *Capture,
@@ -110,7 +110,7 @@ func (cs *CapturesService) Get(ctx context.Context, payment, capture string, opt
 
 // Create creates a new capture for a payment.
 //
-// See: https://docs.mollie.com/reference/v2/captures-api/create-capture
+// See: https://docs.mollie.com/reference/create-capture
 func (cs *CapturesService) Create(ctx context.Context, payment string, capture CreateCapture) (
 	res *Response,
 	c *Capture,
@@ -136,7 +136,7 @@ func (cs *CapturesService) Create(ctx context.Context, payment string, capture C
 
 // List retrieves all captures for a certain payment.
 //
-// See: https://docs.mollie.com/reference/v2/captures-api/list-captures
+// See: https://docs.mollie.com/reference/list-captures
 func (cs *CapturesService) List(ctx context.Context, payment string, options *CaptureOptions) (
 	res *Response,
 	cl *CapturesList,

--- a/mollie/chargebacks.go
+++ b/mollie/chargebacks.go
@@ -72,7 +72,7 @@ type ChargebacksService service
 // Get retrieves a single chargeback by its ID.
 // Note the original payment’s ID is needed as well.
 //
-// See: https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback
+// See: https://docs.mollie.com/reference/get-chargeback
 func (cs *ChargebacksService) Get(ctx context.Context, payment, chargeback string, opts *ChargebackOptions) (
 	res *Response,
 	p *Chargeback,
@@ -94,7 +94,7 @@ func (cs *ChargebacksService) Get(ctx context.Context, payment, chargeback strin
 
 // List retrieves a list of chargebacks associated with your account/organization.
 //
-// See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+// See: https://docs.mollie.com/reference/list-chargebacks
 func (cs *ChargebacksService) List(ctx context.Context, options *ListChargebacksOptions) (
 	res *Response,
 	cl *ChargebacksList,
@@ -105,7 +105,7 @@ func (cs *ChargebacksService) List(ctx context.Context, options *ListChargebacks
 
 // ListForPayment retrieves a list of chargebacks associated with a single payment.
 //
-// See: https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks
+// See: https://docs.mollie.com/reference/list-chargebacks
 func (cs *ChargebacksService) ListForPayment(ctx context.Context, payment string, options *ListChargebacksOptions) (
 	res *Response,
 	cl *ChargebacksList,

--- a/mollie/client_links.go
+++ b/mollie/client_links.go
@@ -38,7 +38,7 @@ type ClientLinksService service
 
 // Create a client link based on the provided CreateClientLink values.
 //
-// See: https://docs.mollie.com/reference/v2/client-links-api/create-client-link
+// See: https://docs.mollie.com/reference/create-client-link
 func (cls *ClientLinksService) Create(ctx context.Context, cd CreateClientLink) (
 	res *Response,
 	cl *ClientLink,

--- a/mollie/clients.go
+++ b/mollie/clients.go
@@ -49,7 +49,7 @@ type ClientsService service
 
 // List retrieves all clients.
 //
-// See: https://docs.mollie.com/reference/v2/partners-api/list-clients
+// See: https://docs.mollie.com/reference/list-clients
 func (ps *ClientsService) List(ctx context.Context, opts *ListLinkedClientsOptions) (
 	res *Response,
 	pc *LinkedClientList,
@@ -69,7 +69,7 @@ func (ps *ClientsService) List(ctx context.Context, opts *ListLinkedClientsOptio
 
 // Get retrieves a single client, linked to your partner account, by its ID.
 //
-// See: https://docs.mollie.com/reference/v2/partners-api/get-client
+// See: https://docs.mollie.com/reference/get-client
 func (ps *ClientsService) Get(ctx context.Context, id string, opts *GetLinkedClientOptions) (
 	res *Response,
 	pc *LinkedClient,

--- a/mollie/customers.go
+++ b/mollie/customers.go
@@ -70,7 +70,7 @@ type CustomersService service
 
 // Get finds a customer by its ID.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/get-customer
+// See: https://docs.mollie.com/reference/get-customer
 func (cs *CustomersService) Get(ctx context.Context, id string) (res *Response, c *Customer, err error) {
 	u := fmt.Sprintf("v2/customers/%s", id)
 
@@ -89,7 +89,7 @@ func (cs *CustomersService) Get(ctx context.Context, id string) (res *Response, 
 // Create creates a simple minimal representation of a customer in the Mollie API
 // to use for the Mollie Checkout and Recurring features.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/create-customer
+// See: https://docs.mollie.com/reference/create-customer
 func (cs *CustomersService) Create(ctx context.Context, c CreateCustomer) (res *Response, cc *Customer, err error) {
 	res, err = cs.client.post(ctx, "v2/customers", c, nil)
 	if err != nil {
@@ -105,7 +105,7 @@ func (cs *CustomersService) Create(ctx context.Context, c CreateCustomer) (res *
 
 // Update an existing customer.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/update-customer
+// See: https://docs.mollie.com/reference/update-customer
 func (cs *CustomersService) Update(ctx context.Context, id string, c UpdateCustomer) (
 	res *Response,
 	cc *Customer,
@@ -129,7 +129,7 @@ func (cs *CustomersService) Update(ctx context.Context, id string, c UpdateCusto
 //
 // All mandates and subscriptions created for this customer will be canceled as well.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/delete-customer
+// See: https://docs.mollie.com/reference/delete-customer
 func (cs *CustomersService) Delete(ctx context.Context, id string) (res *Response, err error) {
 	u := fmt.Sprintf("v2/customers/%s", id)
 
@@ -143,7 +143,7 @@ func (cs *CustomersService) Delete(ctx context.Context, id string) (res *Respons
 
 // List retrieves all customers created.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/list-customers
+// See: https://docs.mollie.com/reference/list-customers
 func (cs *CustomersService) List(ctx context.Context, options *ListCustomersOptions) (
 	res *Response,
 	cl *CustomersList,
@@ -163,7 +163,7 @@ func (cs *CustomersService) List(ctx context.Context, options *ListCustomersOpti
 
 // GetPayments retrieves all payments linked to the customer.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/list-customer-payments
+// See: https://docs.mollie.com/reference/list-customer-payments
 func (cs *CustomersService) GetPayments(ctx context.Context, id string, options *ListCustomersOptions) (
 	res *Response,
 	pl *PaymentList,
@@ -185,7 +185,7 @@ func (cs *CustomersService) GetPayments(ctx context.Context, id string, options 
 
 // CreatePayment creates a payment for the customer.
 //
-// See: https://docs.mollie.com/reference/v2/customers-api/create-customer-payment
+// See: https://docs.mollie.com/reference/create-customer-payment
 func (cs *CustomersService) CreatePayment(ctx context.Context, id string, p CreatePayment) (
 	res *Response,
 	pp *Payment,

--- a/mollie/mandates.go
+++ b/mollie/mandates.go
@@ -117,7 +117,7 @@ type MandatesList struct {
 //
 // Mandates allow you to charge a customer’s credit card or bank account recurrently.
 //
-// See: https://docs.mollie.com/reference/v2/mandates-api/create-mandate
+// See: https://docs.mollie.com/reference/create-mandate
 func (ms *MandatesService) Create(ctx context.Context, customer string, mandate CreateMandate) (
 	res *Response,
 	mr *Mandate,
@@ -145,7 +145,7 @@ func (ms *MandatesService) Create(ctx context.Context, customer string, mandate 
 // The mandate will either contain IBAN or credit card details,
 // depending on the type of mandate.
 //
-// See: https://docs.mollie.com/reference/v2/mandates-api/get-mandate
+// See: https://docs.mollie.com/reference/get-mandate
 func (ms *MandatesService) Get(ctx context.Context, customer, mandate string) (res *Response, mr *Mandate, err error) {
 	u := fmt.Sprintf("v2/customers/%s/mandates/%s", customer, mandate)
 
@@ -166,7 +166,7 @@ func (ms *MandatesService) Get(ctx context.Context, customer, mandate string) (r
 // You will no longer be able to charge the consumer’s bank account
 // or credit card with this mandate and all connected subscriptions will be canceled.
 //
-// See: https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate
+// See: https://docs.mollie.com/reference/revoke-mandate
 func (ms *MandatesService) Revoke(ctx context.Context, customer, mandate string) (res *Response, err error) {
 	u := fmt.Sprintf("v2/customers/%s/mandates/%s", customer, mandate)
 
@@ -181,7 +181,7 @@ func (ms *MandatesService) Revoke(ctx context.Context, customer, mandate string)
 // List retrieves all mandates for the given customerId,
 // ordered from newest to oldest.
 //
-// See: https://docs.mollie.com/reference/v2/mandates-api/list-mandates
+// See: https://docs.mollie.com/reference/list-mandates
 func (ms *MandatesService) List(ctx context.Context, customer string, options *ListMandatesOptions) (
 	res *Response,
 	ml *MandatesList,

--- a/mollie/onboarding.go
+++ b/mollie/onboarding.go
@@ -74,7 +74,7 @@ type OnboardingService service
 
 // GetOnboardingStatus gets the status of onboarding of the authenticated organization.
 //
-// See: https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status
+// See: https://docs.mollie.com/reference/get-onboarding-status
 func (os *OnboardingService) GetOnboardingStatus(ctx context.Context) (res *Response, o *Onboarding, err error) {
 	res, err = os.client.get(ctx, onboardingURLPath, nil)
 	if err != nil {
@@ -94,7 +94,7 @@ func (os *OnboardingService) GetOnboardingStatus(ctx context.Context) (res *Resp
 // This endpoint has been deprecated. It will be supported for the foreseeable future, but new implementations should
 // use the Create client link endpoint to create new clients and submit their organization’s details in one go.
 //
-// See: https://docs.mollie.com/reference/v2/onboarding-api/submit-onboarding-data
+// See: https://docs.mollie.com/reference/submit-onboarding-data
 func (os *OnboardingService) SubmitOnboardingData(ctx context.Context, d *OnboardingData) (res *Response, err error) {
 	res, err = os.client.post(ctx, onboardingURLPath, d, nil)
 	if err != nil {

--- a/mollie/orders.go
+++ b/mollie/orders.go
@@ -325,7 +325,7 @@ type OrdersService service
 
 // Get retrieve a single order by its ID.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/get-order
+// See https://docs.mollie.com/reference/get-order
 func (ors *OrdersService) Get(ctx context.Context, orID string, opts *OrderOptions) (
 	res *Response,
 	order *Order,
@@ -345,7 +345,7 @@ func (ors *OrdersService) Get(ctx context.Context, orID string, opts *OrderOptio
 
 // Create an order will automatically create the required payment to allow your customer to pay for the order.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/create-order
+// See https://docs.mollie.com/reference/create-order
 func (ors *OrdersService) Create(ctx context.Context, ord CreateOrder, opts *OrderOptions) (
 	res *Response,
 	order *Order,
@@ -369,7 +369,7 @@ func (ors *OrdersService) Create(ctx context.Context, ord CreateOrder, opts *Ord
 
 // Update is used to update the billing and/or shipping address of an order.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/update-order
+// See https://docs.mollie.com/reference/update-order
 func (ors *OrdersService) Update(ctx context.Context, orderID string, ord UpdateOrder) (
 	res *Response,
 	order *Order,
@@ -393,7 +393,7 @@ func (ors *OrdersService) Update(ctx context.Context, orderID string, ord Update
 
 // Cancel try to cancel the order that fulfill certain requirements.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/cancel-order
+// See https://docs.mollie.com/reference/cancel-order
 func (ors *OrdersService) Cancel(ctx context.Context, orderID string) (res *Response, order *Order, err error) {
 	res, err = ors.client.delete(ctx, fmt.Sprintf("v2/orders/%s", orderID))
 	if err != nil {
@@ -409,7 +409,7 @@ func (ors *OrdersService) Cancel(ctx context.Context, orderID string) (res *Resp
 
 // List is to retrieve all orders.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/list-orders
+// See https://docs.mollie.com/reference/list-orders
 func (ors *OrdersService) List(ctx context.Context, opts *ListOrdersOptions) (
 	res *Response,
 	ordList *OrdersList,
@@ -429,7 +429,7 @@ func (ors *OrdersService) List(ctx context.Context, opts *ListOrdersOptions) (
 
 // UpdateOrderLine can be used to update an order line.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/update-orderline
+// See https://docs.mollie.com/reference/update-orderline
 func (ors *OrdersService) UpdateOrderLine(
 	ctx context.Context,
 	orderID string,
@@ -461,7 +461,7 @@ func (ors *OrdersService) UpdateOrderLine(
 // that were previously authorized using a pay after delivery payment method.
 // Use the Cancel Order API if you want to cancel the entire order or the remainder of the order.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines
+// See https://docs.mollie.com/reference/cancel-order-lines
 func (ors *OrdersService) CancelOrderLines(ctx context.Context, orderID string, orderLines []OrderLine) (
 	res *Response,
 	err error,
@@ -479,7 +479,7 @@ func (ors *OrdersService) CancelOrderLines(ctx context.Context, orderID string, 
 // CreateOrderPayment can only be created while the status of the order is created,
 // and when the status of the existing payment is either expired, canceled or failed.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/create-order-payment
+// See https://docs.mollie.com/reference/create-order-payment
 func (ors *OrdersService) CreateOrderPayment(ctx context.Context, orderID string, ordPay *OrderPayment) (
 	res *Response,
 	payment *Payment,
@@ -501,7 +501,7 @@ func (ors *OrdersService) CreateOrderPayment(ctx context.Context, orderID string
 
 // CreateOrderRefund using the Orders API, refunds should be made against the order.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/create-order-refund
+// See https://docs.mollie.com/reference/create-order-refund
 func (ors *OrdersService) CreateOrderRefund(ctx context.Context, orderID string, order *Order) (
 	res *Response,
 	refund *Refund,
@@ -523,7 +523,7 @@ func (ors *OrdersService) CreateOrderRefund(ctx context.Context, orderID string,
 
 // ListOrderRefunds retrieve all order refunds.
 //
-// See https://docs.mollie.com/reference/v2/orders-api/list-order-refunds
+// See https://docs.mollie.com/reference/list-order-refunds
 func (ors *OrdersService) ListOrderRefunds(ctx context.Context, orderID string, opts *ListOrderRefundsOptions) (
 	res *Response,
 	orderListRefund *OrderRefundsList,
@@ -545,7 +545,7 @@ func (ors *OrdersService) ListOrderRefunds(ctx context.Context, orderID string, 
 
 // ManageOrderLines allows to update, cancel, or add one or more order lines.
 //
-// See: https://docs.mollie.com/reference/v2/orders-api/manage-order-lines
+// See: https://docs.mollie.com/reference/manage-order-lines
 func (ors *OrdersService) ManageOrderLines(ctx context.Context, orderID string, operations *OrderLineOperations) (
 	res *Response,
 	order *Order,

--- a/mollie/organizations.go
+++ b/mollie/organizations.go
@@ -88,7 +88,7 @@ func (os *OrganizationsService) GetCurrent(ctx context.Context) (res *Response, 
 // GetPartnerStatus retrieves details about the partner status
 // of the currently authenticated organization.
 //
-// See: https://docs.mollie.com/reference/v2/organizations-api/get-partner
+// See: https://docs.mollie.com/reference/get-partner
 func (os *OrganizationsService) GetPartnerStatus(ctx context.Context) (
 	res *Response,
 	ops *OrganizationPartnerStatus,

--- a/mollie/payment_links.go
+++ b/mollie/payment_links.go
@@ -11,7 +11,7 @@ import (
 // and will redirect them to them the payment page where they can
 // complete the payment.
 //
-// See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+// See: https://docs.mollie.com/reference/get-payment-link
 type PaymentLink struct {
 	ID          string           `json:"id,omitempty"`
 	Resource    string           `json:"resource,omitempty"`
@@ -31,7 +31,7 @@ type PaymentLink struct {
 // PaymentLinkLinks describes all the possible links returned with
 // a payment link struct.
 //
-// See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+// See: https://docs.mollie.com/reference/get-payment-link
 type PaymentLinkLinks struct {
 	Self          *URL `json:"self,omitempty"`
 	Documentation *URL `json:"documentation,omitempty"`
@@ -70,7 +70,7 @@ type PaymentLinksService service
 
 // Get retrieves a single payment link object by its id/token.
 //
-// See: https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link
+// See: https://docs.mollie.com/reference/get-payment-link
 func (pls *PaymentLinksService) Get(ctx context.Context, id string) (res *Response, pl *PaymentLink, err error) {
 	res, err = pls.client.get(ctx, fmt.Sprintf("v2/payment-links/%s", id), nil)
 	if err != nil {
@@ -86,7 +86,7 @@ func (pls *PaymentLinksService) Get(ctx context.Context, id string) (res *Respon
 
 // Create generates payment links that by default, unlike regular payments, do not expire.
 //
-// See: https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link
+// See: https://docs.mollie.com/reference/create-payment-link
 func (pls *PaymentLinksService) Create(ctx context.Context, p PaymentLink, opts *PaymentLinkOptions) (
 	res *Response,
 	np *PaymentLink,
@@ -107,7 +107,7 @@ func (pls *PaymentLinksService) Create(ctx context.Context, p PaymentLink, opts 
 // List retrieves all payments links created with the current website profile,
 // ordered from newest to oldest.
 //
-// See: https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links
+// See: https://docs.mollie.com/reference/list-payment-links
 func (pls *PaymentLinksService) List(ctx context.Context, opts *PaymentLinkOptions) (
 	res *Response,
 	pl *PaymentLinksList,

--- a/mollie/payment_methods.go
+++ b/mollie/payment_methods.go
@@ -98,7 +98,7 @@ type PaymentMethodsService service
 // it also receives a pointer to the method options containing applicable
 // query string parameters.
 //
-// See: https://docs.mollie.com/reference/v2/methods-api/get-method
+// See: https://docs.mollie.com/reference/get-method
 func (ms *PaymentMethodsService) Get(ctx context.Context, id PaymentMethod, options *PaymentMethodOptions) (
 	res *Response,
 	pmd *PaymentMethodDetails,
@@ -120,7 +120,7 @@ func (ms *PaymentMethodsService) Get(ctx context.Context, id PaymentMethod, opti
 
 // All retrieves all the payment methods enabled for your account/organization.
 //
-// See: https://docs.mollie.com/reference/v2/methods-api/list-all-methods
+// See: https://docs.mollie.com/reference/list-all-methods
 func (ms *PaymentMethodsService) All(ctx context.Context, options *ListPaymentMethodsOptions) (
 	res *Response,
 	pm *PaymentMethodsList,
@@ -133,7 +133,7 @@ func (ms *PaymentMethodsService) All(ctx context.Context, options *ListPaymentMe
 //
 // The results are not paginated.
 //
-// See: https://docs.mollie.com/reference/v2/methods-api/list-methods
+// See: https://docs.mollie.com/reference/list-methods
 func (ms *PaymentMethodsService) List(ctx context.Context, options *ListPaymentMethodsOptions) (
 	res *Response,
 	pm *PaymentMethodsList,

--- a/mollie/payments.go
+++ b/mollie/payments.go
@@ -62,7 +62,7 @@ type PaymentDestination struct {
 // Some fields are only valid for specific payment methods, and are
 // documented in the Mollie API reference.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#payment-method-specific-parameters
+// See: https://docs.mollie.com/reference/create-payment#payment-method-specific-parameters
 type CreatePayment struct {
 	Description                     string          `json:"description,omitempty"`
 	RedirectURL                     string          `json:"redirectUrl,omitempty"`
@@ -106,7 +106,7 @@ type CreatePayment struct {
 // CreateRecurrentPaymentFields describes the fields to be sent to the Mollie API when
 // creating a new recurrent payment.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#parameters-for-recurring-payments
+// See: https://docs.mollie.com/reference/create-payment#parameters-for-recurring-payments
 type CreateRecurrentPaymentFields struct {
 	CustomerID   string       `json:"customerId,omitempty"`
 	MandateID    string       `json:"mandateId,omitempty"`
@@ -116,7 +116,7 @@ type CreateRecurrentPaymentFields struct {
 // CreatePreAuthorizedPaymentFields describes the fields to be sent to the Mollie API when
 // creating a new pre-authorized payment.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#parameters-for-pre-authorized-payments
+// See: https://docs.mollie.com/reference/create-payment#parameters-for-pre-authorized-payments
 type CreatePreAuthorizedPaymentFields struct {
 	CaptureDelay string      `json:"captureDelay,omitempty"`
 	CaptureMode  CaptureMode `json:"captureMode,omitempty"`
@@ -125,7 +125,7 @@ type CreatePreAuthorizedPaymentFields struct {
 // CreatePaymentAccessTokenFields describes the fields to be sent to the Mollie API when
 // creating a new payment using an access token.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#access-token-parameters
+// See: https://docs.mollie.com/reference/create-payment#access-token-parameters
 type CreatePaymentAccessTokenFields struct {
 	ProfileID string `json:"profileId,omitempty"`
 	Testmode  bool   `json:"testmode,omitempty"`
@@ -134,7 +134,7 @@ type CreatePaymentAccessTokenFields struct {
 // CreateMollieConnectPaymentFields describes the fields to be sent to the Mollie API when
 // creating a new payment using Mollie Connect.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#mollie-connect-parameters
+// See: https://docs.mollie.com/reference/create-payment#mollie-connect-parameters
 type CreateMollieConnectPaymentFields struct {
 	ApplicationFee *ApplicationFee   `json:"applicationFee,omitempty"`
 	Routing        []*PaymentRouting `json:"routing,omitempty"`
@@ -174,8 +174,8 @@ type PaymentLines struct {
 // UpdatePayment describes the payload to be sent to the Mollie API when
 // updating a payment.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/update-payment
-// See: https://docs.mollie.com/reference/v2/payments-api/update-payment#payment-method-specific-parameters
+// See: https://docs.mollie.com/reference/update-payment
+// See: https://docs.mollie.com/reference/update-payment#payment-method-specific-parameters
 type UpdatePayment struct {
 	Description                     string        `json:"description,omitempty"`
 	RedirectURL                     string        `json:"redirectUrl,omitempty"`
@@ -285,7 +285,7 @@ type PaymentLinks struct {
 
 // PaymentOptions describes payments endpoint valid query string parameters.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/get-payment
+// See: https://docs.mollie.com/reference/get-payment
 type PaymentOptions struct {
 	Include []IncludeValue `url:"include,omitempty"`
 	Embed   []EmbedValue   `url:"embed,omitempty"`
@@ -323,7 +323,7 @@ func (ps *PaymentsService) Get(ctx context.Context, id string, opts *PaymentOpti
 
 // Create stores a new payment object attached to your Mollie account.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/create-payment#
+// See: https://docs.mollie.com/reference/create-payment#
 func (ps *PaymentsService) Create(ctx context.Context, p CreatePayment, opts *PaymentOptions) (
 	res *Response,
 	np *Payment,
@@ -347,7 +347,7 @@ func (ps *PaymentsService) Create(ctx context.Context, p CreatePayment, opts *Pa
 
 // Cancel removes a payment (if possible) from your Mollie account.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/cancel-payment
+// See: https://docs.mollie.com/reference/cancel-payment
 func (ps *PaymentsService) Cancel(ctx context.Context, id string) (res *Response, p *Payment, err error) {
 	res, err = ps.client.delete(ctx, fmt.Sprintf("v2/payments/%s", id))
 	if err != nil {
@@ -363,7 +363,7 @@ func (ps *PaymentsService) Cancel(ctx context.Context, id string) (res *Response
 
 // Update can be used to update some details of a created payment.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/update-payment
+// See: https://docs.mollie.com/reference/update-payment
 func (ps *PaymentsService) Update(ctx context.Context, id string, up UpdatePayment) (
 	res *Response,
 	p *Payment,
@@ -392,7 +392,7 @@ type PaymentList struct {
 
 // List retrieves a list of payments associated with your account/organization.
 //
-// See: https://docs.mollie.com/reference/v2/payments-api/list-payments
+// See: https://docs.mollie.com/reference/list-payments
 func (ps *PaymentsService) List(ctx context.Context, opts *ListPaymentsOptions) (
 	res *Response,
 	pl *PaymentList,

--- a/mollie/permissions.go
+++ b/mollie/permissions.go
@@ -72,7 +72,7 @@ type PermissionsService service
 
 // Get returns a permission by its id.
 //
-// See: https://docs.mollie.com/reference/v2/permissions-api/get-permission
+// See: https://docs.mollie.com/reference/get-permission
 func (ps *PermissionsService) Get(ctx context.Context, id PermissionGrant) (res *Response, p *Permission, err error) {
 	res, err = ps.client.get(ctx, fmt.Sprintf("v2/permissions/%s", id), nil)
 	if err != nil {
@@ -89,7 +89,7 @@ func (ps *PermissionsService) Get(ctx context.Context, id PermissionGrant) (res 
 // List retrieves all permissions available with the current app access token.
 // The list is not paginated.
 //
-// See: https://docs.mollie.com/reference/v2/permissions-api/list-permissions
+// See: https://docs.mollie.com/reference/list-permissions
 func (ps *PermissionsService) List(ctx context.Context) (res *Response, pl *PermissionsList, err error) {
 	res, err = ps.client.get(ctx, "v2/permissions", nil)
 	if err != nil {

--- a/mollie/profiles.go
+++ b/mollie/profiles.go
@@ -225,7 +225,7 @@ func (ps *ProfilesService) DisablePaymentMethod(ctx context.Context, id string, 
 // EnableGiftCardIssuer activates the requested gift card issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+// See: https://docs.mollie.com/reference/enable-gift-card-issuer
 func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID string, issuer GiftCardIssuer) (
 	res *Response,
 	gc *GiftCardEnabled,
@@ -246,7 +246,7 @@ func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID s
 // DisableGiftCardIssuer deactivates the requested gift card issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+// See: https://docs.mollie.com/reference/disable-gift-card-issuer
 func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID string, issuer GiftCardIssuer) (
 	res *Response,
 	err error,
@@ -262,7 +262,7 @@ func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID 
 // EnableGiftCardIssuerForCurrent activates the specified issuer for the
 // current profile when using API tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/enable-gift-card-issuer
+// See: https://docs.mollie.com/reference/enable-gift-card-issuer
 func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, issuer GiftCardIssuer) (
 	res *Response,
 	gc *GiftCardEnabled,
@@ -283,7 +283,7 @@ func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, i
 // DisableGiftCardIssuerForCurrent deactivates the specified issuer for the
 // current profile when using API tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/disable-gift-card-issuer
+// See: https://docs.mollie.com/reference/disable-gift-card-issuer
 func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, issuer GiftCardIssuer) (
 	res *Response,
 	err error,
@@ -299,7 +299,7 @@ func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, 
 // EnableVoucherIssuer activates the requested voucher issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer
+// See: https://docs.mollie.com/reference/enable-voucher-issuer
 func (ps *ProfilesService) EnableVoucherIssuer(
 	ctx context.Context,
 	profileID string,
@@ -325,7 +325,7 @@ func (ps *ProfilesService) EnableVoucherIssuer(
 // DisableVoucherIssuer deactivates the requested voucher issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/v2/profiles-api/disable-voucher-issuer
+// See: https://docs.mollie.com/reference/disable-voucher-issuer
 func (ps *ProfilesService) DisableVoucherIssuer(ctx context.Context, profileID string, issuer VoucherIssuer) (
 	res *Response,
 	err error,

--- a/mollie/profiles.go
+++ b/mollie/profiles.go
@@ -225,7 +225,7 @@ func (ps *ProfilesService) DisablePaymentMethod(ctx context.Context, id string, 
 // EnableGiftCardIssuer activates the requested gift card issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/enable-gift-card-issuer
+// See: https://docs.mollie.com/reference/enable-method-issuer
 func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID string, issuer GiftCardIssuer) (
 	res *Response,
 	gc *GiftCardEnabled,
@@ -246,7 +246,7 @@ func (ps *ProfilesService) EnableGiftCardIssuer(ctx context.Context, profileID s
 // DisableGiftCardIssuer deactivates the requested gift card issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/disable-gift-card-issuer
+// See: https://docs.mollie.com/reference/disable-method-issuer
 func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID string, issuer GiftCardIssuer) (
 	res *Response,
 	err error,
@@ -262,7 +262,7 @@ func (ps *ProfilesService) DisableGiftCardIssuer(ctx context.Context, profileID 
 // EnableGiftCardIssuerForCurrent activates the specified issuer for the
 // current profile when using API tokens.
 //
-// See: https://docs.mollie.com/reference/enable-gift-card-issuer
+// See: https://docs.mollie.com/reference/enable-method-issuer
 func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, issuer GiftCardIssuer) (
 	res *Response,
 	gc *GiftCardEnabled,
@@ -283,7 +283,7 @@ func (ps *ProfilesService) EnableGiftCardIssuerForCurrent(ctx context.Context, i
 // DisableGiftCardIssuerForCurrent deactivates the specified issuer for the
 // current profile when using API tokens.
 //
-// See: https://docs.mollie.com/reference/disable-gift-card-issuer
+// See: https://docs.mollie.com/reference/disable-method-issuer
 func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, issuer GiftCardIssuer) (
 	res *Response,
 	err error,
@@ -299,7 +299,7 @@ func (ps *ProfilesService) DisableGiftCardIssuerForCurrent(ctx context.Context, 
 // EnableVoucherIssuer activates the requested voucher issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/enable-voucher-issuer
+// See: https://docs.mollie.com/reference/enable-method-issuer
 func (ps *ProfilesService) EnableVoucherIssuer(
 	ctx context.Context,
 	profileID string,
@@ -325,7 +325,7 @@ func (ps *ProfilesService) EnableVoucherIssuer(
 // DisableVoucherIssuer deactivates the requested voucher issuer for the provided
 // profile id when using Organization tokens or App Access tokens.
 //
-// See: https://docs.mollie.com/reference/disable-voucher-issuer
+// See: https://docs.mollie.com/reference/disable-method-issuer
 func (ps *ProfilesService) DisableVoucherIssuer(ctx context.Context, profileID string, issuer VoucherIssuer) (
 	res *Response,
 	err error,

--- a/mollie/refunds.go
+++ b/mollie/refunds.go
@@ -122,7 +122,7 @@ type RefundsService service
 
 // List retrieves all refunds.
 //
-// See https://docs.mollie.com/reference/list-refunds.
+// See https://docs.mollie.com/reference/list-all-refunds.
 func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (
 	res *Response,
 	rl *RefundsList,
@@ -142,7 +142,7 @@ func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (
 
 // GetPaymentRefund retrieves a specific refund for a specific payment.
 //
-// See: https://docs.mollie.com/reference/get-payment-refund
+// See: https://docs.mollie.com/reference/get-refund
 func (rs *RefundsService) GetPaymentRefund(
 	ctx context.Context,
 	paymentID, refundID string,
@@ -168,7 +168,7 @@ func (rs *RefundsService) GetPaymentRefund(
 
 // ListPaymentRefunds retrieves all refunds for a specific payment.
 //
-// See: https://docs.mollie.com/reference/list-payment-refunds
+// See: https://docs.mollie.com/reference/list-refunds
 func (rs *RefundsService) ListPaymentRefunds(
 	ctx context.Context,
 	paymentID string,
@@ -194,7 +194,7 @@ func (rs *RefundsService) ListPaymentRefunds(
 
 // Create a refund payment request.
 //
-// See https://docs.mollie.com/reference/create-payment-refund
+// See https://docs.mollie.com/reference/create-refund
 func (rs *RefundsService) CreatePaymentRefund(
 	ctx context.Context,
 	paymentID string,
@@ -225,7 +225,7 @@ func (rs *RefundsService) CreatePaymentRefund(
 
 // CancelPaymentRefund cancels a refund for a specific payment.
 //
-// See https://docs.mollie.com/reference/cancel-payment-refund
+// See https://docs.mollie.com/reference/cancel-refund
 func (rs *RefundsService) CancelPaymentRefund(
 	ctx context.Context, paymentID, refundID string,
 ) (res *Response, err error) {

--- a/mollie/refunds.go
+++ b/mollie/refunds.go
@@ -122,7 +122,7 @@ type RefundsService service
 
 // List retrieves all refunds.
 //
-// See https://docs.mollie.com/reference/v2/refunds-api/list-refunds.
+// See https://docs.mollie.com/reference/list-refunds.
 func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (
 	res *Response,
 	rl *RefundsList,
@@ -142,7 +142,7 @@ func (rs *RefundsService) List(ctx context.Context, opts *ListRefundsOptions) (
 
 // GetPaymentRefund retrieves a specific refund for a specific payment.
 //
-// See: https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund
+// See: https://docs.mollie.com/reference/get-payment-refund
 func (rs *RefundsService) GetPaymentRefund(
 	ctx context.Context,
 	paymentID, refundID string,
@@ -168,7 +168,7 @@ func (rs *RefundsService) GetPaymentRefund(
 
 // ListPaymentRefunds retrieves all refunds for a specific payment.
 //
-// See: https://docs.mollie.com/reference/v2/refunds-api/list-payment-refunds
+// See: https://docs.mollie.com/reference/list-payment-refunds
 func (rs *RefundsService) ListPaymentRefunds(
 	ctx context.Context,
 	paymentID string,
@@ -194,7 +194,7 @@ func (rs *RefundsService) ListPaymentRefunds(
 
 // Create a refund payment request.
 //
-// See https://docs.mollie.com/reference/v2/refunds-api/create-payment-refund
+// See https://docs.mollie.com/reference/create-payment-refund
 func (rs *RefundsService) CreatePaymentRefund(
 	ctx context.Context,
 	paymentID string,
@@ -225,7 +225,7 @@ func (rs *RefundsService) CreatePaymentRefund(
 
 // CancelPaymentRefund cancels a refund for a specific payment.
 //
-// See https://docs.mollie.com/reference/v2/refunds-api/cancel-payment-refund
+// See https://docs.mollie.com/reference/cancel-payment-refund
 func (rs *RefundsService) CancelPaymentRefund(
 	ctx context.Context, paymentID, refundID string,
 ) (res *Response, err error) {
@@ -234,7 +234,7 @@ func (rs *RefundsService) CancelPaymentRefund(
 
 // CreateOrderRefund creates a refund for a specific order.
 //
-// See https://docs.mollie.com/reference/v2/refunds-api/create-order-refund
+// See https://docs.mollie.com/reference/create-order-refund
 func (rs *RefundsService) CreateOrderRefund(
 	ctx context.Context,
 	orderID string,
@@ -264,7 +264,7 @@ func (rs *RefundsService) CreateOrderRefund(
 
 // ListOrderRefunds retrieves all refunds for a specific order.
 //
-// See https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds
+// See https://docs.mollie.com/reference/list-order-refunds
 func (rs *RefundsService) ListOrderRefunds(
 	ctx context.Context,
 	orderID string,

--- a/mollie/settlements.go
+++ b/mollie/settlements.go
@@ -141,7 +141,7 @@ func (ss *SettlementsService) List(ctx context.Context, slo *ListSettlementsOpti
 // ListPayments retrieves all payments included in a settlement.
 // This API is an alias of the List payments.
 //
-// See: https://docs.mollie.com/reference/list-settlement-payments
+// See: https://docs.mollie.com/reference/get-settlement-payments
 func (ss *SettlementsService) ListPayments(ctx context.Context, settlement string, options *ListPaymentsOptions) (
 	res *Response,
 	pl *PaymentList,
@@ -161,7 +161,7 @@ func (ss *SettlementsService) ListPayments(ctx context.Context, settlement strin
 
 // GetRefunds retrieves all refunds included in a settlement.
 //
-// See: https://docs.mollie.com/reference/list-settlement-refunds
+// See: https://docs.mollie.com/reference/get-settlement-refunds
 func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string, slo *ListSettlementsOptions) (
 	res *Response,
 	rl *RefundsList,
@@ -181,7 +181,7 @@ func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string,
 
 // GetChargebacks retrieves all chargebacks included in a settlement.
 //
-// See: https://docs.mollie.com/reference/list-settlement-chargebacks
+// See: https://docs.mollie.com/reference/get-settlement-chargebacks
 func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement string, slo *ListChargebacksOptions) (
 	res *Response,
 	cl *ChargebacksList,
@@ -201,7 +201,7 @@ func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement str
 
 // GetCaptures retrieves all captures included in a settlement.
 //
-// See: https://docs.mollie.com/reference/list-settlement-captures
+// See: https://docs.mollie.com/reference/get-settlement-captures
 func (ss *SettlementsService) GetCaptures(ctx context.Context, settlement string, slo *ListSettlementsOptions) (
 	res *Response,
 	cl *CapturesList,

--- a/mollie/settlements.go
+++ b/mollie/settlements.go
@@ -98,14 +98,14 @@ type SettlementsService service
 
 // Get returns a settlement by its id or the bank reference id
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/get-settlement
+// See: https://docs.mollie.com/reference/get-settlement
 func (ss *SettlementsService) Get(ctx context.Context, settlement string) (res *Response, s *Settlement, err error) {
 	return ss.get(ctx, settlement)
 }
 
 // Next retrieves the details of the current settlement that has not yet been paid out.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement
+// See: https://docs.mollie.com/reference/get-next-settlement
 func (ss *SettlementsService) Next(ctx context.Context) (res *Response, s *Settlement, err error) {
 	return ss.get(ctx, "next")
 }
@@ -113,14 +113,14 @@ func (ss *SettlementsService) Next(ctx context.Context) (res *Response, s *Settl
 // Open retrieves the details of the open balance of the organization.
 // This will return a settlement object representing your organization’s balance.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/get-open-settlement
+// See: https://docs.mollie.com/reference/get-open-settlement
 func (ss *SettlementsService) Open(ctx context.Context) (res *Response, s *Settlement, err error) {
 	return ss.get(ctx, "open")
 }
 
 // List retrieves all settlements, ordered from new to old
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/list-settlements
+// See: https://docs.mollie.com/reference/list-settlements
 func (ss *SettlementsService) List(ctx context.Context, slo *ListSettlementsOptions) (
 	res *Response,
 	sl *SettlementsList,
@@ -141,7 +141,7 @@ func (ss *SettlementsService) List(ctx context.Context, slo *ListSettlementsOpti
 // ListPayments retrieves all payments included in a settlement.
 // This API is an alias of the List payments.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-payments
+// See: https://docs.mollie.com/reference/list-settlement-payments
 func (ss *SettlementsService) ListPayments(ctx context.Context, settlement string, options *ListPaymentsOptions) (
 	res *Response,
 	pl *PaymentList,
@@ -161,7 +161,7 @@ func (ss *SettlementsService) ListPayments(ctx context.Context, settlement strin
 
 // GetRefunds retrieves all refunds included in a settlement.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-refunds
+// See: https://docs.mollie.com/reference/list-settlement-refunds
 func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string, slo *ListSettlementsOptions) (
 	res *Response,
 	rl *RefundsList,
@@ -181,7 +181,7 @@ func (ss *SettlementsService) GetRefunds(ctx context.Context, settlement string,
 
 // GetChargebacks retrieves all chargebacks included in a settlement.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-chargebacks
+// See: https://docs.mollie.com/reference/list-settlement-chargebacks
 func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement string, slo *ListChargebacksOptions) (
 	res *Response,
 	cl *ChargebacksList,
@@ -201,7 +201,7 @@ func (ss *SettlementsService) GetChargebacks(ctx context.Context, settlement str
 
 // GetCaptures retrieves all captures included in a settlement.
 //
-// See: https://docs.mollie.com/reference/v2/settlements-api/list-settlement-captures
+// See: https://docs.mollie.com/reference/list-settlement-captures
 func (ss *SettlementsService) GetCaptures(ctx context.Context, settlement string, slo *ListSettlementsOptions) (
 	res *Response,
 	cl *CapturesList,

--- a/mollie/shipments.go
+++ b/mollie/shipments.go
@@ -68,7 +68,7 @@ type ShipmentsService service
 
 // Get retrieves a single shipment and the order lines shipped by a shipment’s ID.
 //
-// See: https://docs.mollie.com/reference/v2/shipments-api/get-shipment#
+// See: https://docs.mollie.com/reference/get-shipment#
 func (ss *ShipmentsService) Get(ctx context.Context, order string, shipment string) (
 	res *Response,
 	s *Shipment,
@@ -90,7 +90,7 @@ func (ss *ShipmentsService) Get(ctx context.Context, order string, shipment stri
 
 // Create can be used to ship order lines.
 //
-// See: https://docs.mollie.com/reference/v2/shipments-api/create-shipment
+// See: https://docs.mollie.com/reference/create-shipment
 func (ss *ShipmentsService) Create(ctx context.Context, order string, cs CreateShipment) (
 	res *Response,
 	s *Shipment,
@@ -116,7 +116,7 @@ func (ss *ShipmentsService) Create(ctx context.Context, order string, cs CreateS
 
 // List retrieves all shipments for an order.
 //
-// See: https://docs.mollie.com/reference/v2/shipments-api/list-shipments
+// See: https://docs.mollie.com/reference/list-shipments
 func (ss *ShipmentsService) List(ctx context.Context, order string) (res *Response, sl *ShipmentsList, err error) {
 	u := fmt.Sprintf("v2/orders/%s/shipments", order)
 
@@ -134,7 +134,7 @@ func (ss *ShipmentsService) List(ctx context.Context, order string) (res *Respon
 
 // Update can be used to update the tracking information of a shipment
 //
-// See: https://docs.mollie.com/reference/v2/shipments-api/update-shipment
+// See: https://docs.mollie.com/reference/update-shipment
 func (ss *ShipmentsService) Update(ctx context.Context, order string, shipment string, us UpdateShipment) (
 	res *Response,
 	s *Shipment,

--- a/mollie/subscriptions.go
+++ b/mollie/subscriptions.go
@@ -246,7 +246,7 @@ func (ss *SubscriptionsService) List(ctx context.Context, customer string, opts 
 
 // ListPayments retrieves all payments of a specific subscriptions of a customer
 //
-// See: https://docs.mollie.com/reference/list-subscriptions-payments
+// See: https://docs.mollie.com/reference/list-subscription-payments
 func (ss *SubscriptionsService) ListPayments(
 	ctx context.Context,
 	customer, subscription string,

--- a/mollie/subscriptions.go
+++ b/mollie/subscriptions.go
@@ -108,7 +108,7 @@ type SubscriptionsService service
 
 // Get retrieves a customer's subscription
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription
+// See: https://docs.mollie.com/reference/get-subscription
 func (ss *SubscriptionsService) Get(ctx context.Context, customer, subscription string) (
 	res *Response,
 	s *Subscription,
@@ -130,7 +130,7 @@ func (ss *SubscriptionsService) Get(ctx context.Context, customer, subscription 
 
 // Create stores a new subscription for a given customer
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/create-subscription
+// See: https://docs.mollie.com/reference/create-subscription
 func (ss *SubscriptionsService) Create(ctx context.Context, customer string, sc CreateSubscription) (
 	res *Response,
 	s *Subscription,
@@ -156,7 +156,7 @@ func (ss *SubscriptionsService) Create(ctx context.Context, customer string, sc 
 
 // Update changes fields on a subscription object
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/update-subscription
+// See: https://docs.mollie.com/reference/update-subscription
 func (ss *SubscriptionsService) Update(ctx context.Context, customer, subscription string, sc UpdateSubscription) (
 	res *Response,
 	s *Subscription,
@@ -178,7 +178,7 @@ func (ss *SubscriptionsService) Update(ctx context.Context, customer, subscripti
 
 // Cancel cancels a subscription.
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription
+// See: https://docs.mollie.com/reference/cancel-subscription
 func (ss *SubscriptionsService) Cancel(ctx context.Context, customer, subscription string) (
 	res *Response,
 	s *Subscription,
@@ -202,7 +202,7 @@ func (ss *SubscriptionsService) Cancel(ctx context.Context, customer, subscripti
 // By using an API key all the subscriptions created with the current website profile will be returned.
 // In the case of an OAuth Access Token relies the website profile on the profileId field
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions
+// See: https://docs.mollie.com/reference/list-all-subscriptions
 func (ss *SubscriptionsService) All(ctx context.Context, opts *ListSubscriptionsOptions) (
 	res *Response,
 	sl *SubscriptionsList,
@@ -224,7 +224,7 @@ func (ss *SubscriptionsService) All(ctx context.Context, opts *ListSubscriptions
 
 // List retrieves all subscriptions of a customer
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions
+// See: https://docs.mollie.com/reference/list-subscriptions
 func (ss *SubscriptionsService) List(ctx context.Context, customer string, opts *ListSubscriptionsOptions) (
 	res *Response,
 	sl *SubscriptionsList,
@@ -246,7 +246,7 @@ func (ss *SubscriptionsService) List(ctx context.Context, customer string, opts 
 
 // ListPayments retrieves all payments of a specific subscriptions of a customer
 //
-// See: https://docs.mollie.com/reference/v2/subscriptions-api/list-subscriptions-payments
+// See: https://docs.mollie.com/reference/list-subscriptions-payments
 func (ss *SubscriptionsService) ListPayments(
 	ctx context.Context,
 	customer, subscription string,

--- a/mollie/wallets.go
+++ b/mollie/wallets.go
@@ -38,7 +38,7 @@ type ApplePaymentSessionRequest struct {
 
 // ApplePaymentSession returns an Apple Payment Session object valid for one transaction.
 //
-// See: https://docs.mollie.com/reference/v2/wallets-api/request-apple-pay-payment-session
+// See: https://docs.mollie.com/reference/request-apple-pay-payment-session
 func (ms *WalletsService) ApplePaymentSession(ctx context.Context, asr *ApplePaymentSessionRequest) (
 	res *Response,
 	aps *ApplePaymentSession,

--- a/testdata/balances.go
+++ b/testdata/balances.go
@@ -34,7 +34,7 @@ const GetBalanceResponse = `{
       "type": "application/hal+json"
     },
     "documentation": {
-      "href": "https://docs.mollie.com/reference/v2/balances-api/get-balance",
+      "href": "https://docs.mollie.com/reference/balances-api/get-balance",
       "type": "text/html"
     }
   }
@@ -116,7 +116,7 @@ const ListBalancesResponse = `{
   },
   "_links": {
     "documentation": {
-      "href": "https://docs.mollie.com/reference/v2/balances-api/list-balances",
+      "href": "https://docs.mollie.com/reference/balances-api/list-balances",
       "type": "text/html"
     },
     "self": {
@@ -388,7 +388,7 @@ const GetBalanceReportResponse = `{
     },
     "_links": {
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/balances-api/get-balance-report",
+            "href": "https://docs.mollie.com/reference/balances-api/get-balance-report",
             "type": "text/html"
         },
         "self": {
@@ -465,7 +465,7 @@ const GetBalanceReportByStatus = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/balances-api/get-primary-balance-report",
+            "href": "https://docs.mollie.com/reference/balances-api/get-primary-balance-report",
             "type": "text/html"
         }
     }
@@ -655,7 +655,7 @@ const GetBalanceReportByCategory = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/balances-api/get-primary-balance-report",
+            "href": "https://docs.mollie.com/reference/balances-api/get-primary-balance-report",
             "type": "text/html"
         }
     }
@@ -713,7 +713,7 @@ const ListBalanceTransactionsResponse = `{
   },
   "_links": {
     "documentation": {
-      "href": "https://docs.mollie.com/reference/v2/balances-api/list-balance-transactions",
+      "href": "https://docs.mollie.com/reference/balances-api/list-balance-transactions",
       "type": "text/html"
     },
     "self": {

--- a/testdata/captures.go
+++ b/testdata/captures.go
@@ -38,7 +38,7 @@ const ListCapturesResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/captures-api/get-capture",
+                        "href": "https://docs.mollie.com/reference/captures-api/get-capture",
                         "type": "text/html"
                     }
                 }
@@ -48,7 +48,7 @@ const ListCapturesResponse = `{
     "count": 1,
     "_links": {
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/captures-api/list-captures",
+            "href": "https://docs.mollie.com/reference/captures-api/list-captures",
             "type": "text/html"
         },
         "self": {
@@ -95,7 +95,7 @@ const GetCaptureResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/captures-api/get-capture",
+            "href": "https://docs.mollie.com/reference/captures-api/get-capture",
             "type": "text/html"
         }
     }
@@ -123,7 +123,7 @@ const CreateCaptureResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/captures-api/create-capture",
+            "href": "https://docs.mollie.com/reference/captures-api/create-capture",
             "type": "text/html"
         }
     }
@@ -152,7 +152,7 @@ const CreateCaptureWithAccessTokenResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/captures-api/create-capture",
+            "href": "https://docs.mollie.com/reference/captures-api/create-capture",
             "type": "text/html"
         }
     }

--- a/testdata/chargebacks.go
+++ b/testdata/chargebacks.go
@@ -29,7 +29,7 @@ const (
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/chargebacks-api/get-payment-chargeback",
+            "href": "https://docs.mollie.com/reference/chargebacks-api/get-payment-chargeback",
             "type": "text/html"
         }
     }
@@ -62,7 +62,7 @@ const (
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/chargebacks-api/get-chargeback",
+                        "href": "https://docs.mollie.com/reference/chargebacks-api/get-chargeback",
                         "type": "text/html"
                     }
                 }
@@ -77,7 +77,7 @@ const (
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/chargebacks-api/list-chargebacks",
+            "href": "https://docs.mollie.com/reference/chargebacks-api/list-chargebacks",
             "type": "text/html"
         }
     }

--- a/testdata/client_links.go
+++ b/testdata/client_links.go
@@ -10,7 +10,7 @@ const CreateClientLinkResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/clients-api/create-client-link",
+            "href": "https://docs.mollie.com/reference/clients-api/create-client-link",
             "type": "text/html"
         }
     }

--- a/testdata/customers.go
+++ b/testdata/customers.go
@@ -32,7 +32,7 @@ const GetCustomerResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/customers-api/get-customer",
+            "href": "https://docs.mollie.com/reference/customers-api/get-customer",
             "type": "text/html"
         }
     }
@@ -54,7 +54,7 @@ const CreateCustomerResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/customers-api/create-customer",
+            "href": "https://docs.mollie.com/reference/customers-api/create-customer",
             "type": "text/html"
         }
     }
@@ -76,7 +76,7 @@ const UpdateCustomerResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/customers-api/get-customer",
+            "href": "https://docs.mollie.com/reference/customers-api/get-customer",
             "type": "text/html"
         }
     }
@@ -102,7 +102,7 @@ const ListCustomersResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/customers-api/get-customer",
+                        "href": "https://docs.mollie.com/reference/customers-api/get-customer",
                         "type": "text/html"
                     }
                 }
@@ -122,7 +122,7 @@ const ListCustomersResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/customers-api/list-customers",
+            "href": "https://docs.mollie.com/reference/customers-api/list-customers",
             "type": "text/html"
         }
     }

--- a/testdata/invoices.go
+++ b/testdata/invoices.go
@@ -108,7 +108,7 @@ const ListInvoicesResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/invoices-api/list-invoices",
+            "href": "https://docs.mollie.com/reference/invoices-api/list-invoices",
             "type": "text/html"
         }
     }

--- a/testdata/mandates.go
+++ b/testdata/mandates.go
@@ -25,7 +25,7 @@ const CreateMandateResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/mandates-api/create-mandate",
+            "href": "https://docs.mollie.com/reference/mandates-api/create-mandate",
             "type": "text/html"
         }
     }
@@ -56,7 +56,7 @@ const GetMandateResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/mandates-api/get-mandate",
+            "href": "https://docs.mollie.com/reference/mandates-api/get-mandate",
             "type": "text/html"
         }
     }
@@ -138,7 +138,7 @@ const ListMandatesResponse = `
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/mandates-api/revoke-mandate",
+            "href": "https://docs.mollie.com/reference/mandates-api/revoke-mandate",
             "type": "text/html"
         }
     }

--- a/testdata/methods.go
+++ b/testdata/methods.go
@@ -97,7 +97,7 @@ const ListMethodsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/methods-api/list-methods",
+            "href": "https://docs.mollie.com/reference/methods-api/list-methods",
             "type": "text/html"
         }
     }
@@ -161,7 +161,7 @@ const GetMethodResponse = `{
              "type": "application/hal+json"
          },
          "documentation": {
-             "href": "https://docs.mollie.com/reference/v2/methods-api/get-method",
+             "href": "https://docs.mollie.com/reference/methods-api/get-method",
              "type": "text/html"
          }
      }

--- a/testdata/onboarding.go
+++ b/testdata/onboarding.go
@@ -22,7 +22,7 @@ const GetOnboardingStatusResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/onboarding-api/get-onboarding-status",
+            "href": "https://docs.mollie.com/reference/onboarding-api/get-onboarding-status",
             "type": "text/html"
         }
     }

--- a/testdata/orders.go
+++ b/testdata/orders.go
@@ -281,7 +281,7 @@ const GetOrderResponse = `{
             "type": "text/html"
         },
          "documentation": {
-             "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+             "href": "https://docs.mollie.com/reference/orders-api/get-order",
              "type": "text/html"
          }
      }
@@ -560,7 +560,7 @@ const CreateOrderResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+            "href": "https://docs.mollie.com/reference/orders-api/get-order",
             "type": "text/html"
         }
     }
@@ -749,7 +749,7 @@ const UpdateOrderResponse = `{
 			"type": "text/html"
 		},
 		"documentation": {
-			"href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+			"href": "https://docs.mollie.com/reference/orders-api/get-order",
 			"type": "text/html"
 		}
 	}
@@ -917,7 +917,7 @@ const CancelOrderResponse = `{
 			"type": "text/html"
 		},
 		"documentation": {
-			"href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+			"href": "https://docs.mollie.com/reference/orders-api/get-order",
 			"type": "text/html"
 		}
 	}
@@ -948,7 +948,7 @@ const OrderListResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/orders-api/list-orders",
+            "href": "https://docs.mollie.com/reference/orders-api/list-orders",
             "type": "text/html"
         }
     }
@@ -1144,7 +1144,7 @@ const UpdateOrderLineResponse = `{
 		  "type":"text/html"
 	   },
 	   "documentation":{
-		  "href":"https://docs.mollie.com/reference/v2/orders-api/get-order",
+		  "href":"https://docs.mollie.com/reference/orders-api/get-order",
 		  "type":"text/html"
 	   }
 	}
@@ -1194,7 +1194,7 @@ const CancelOrderLinesResponseAmountRequired = `{
 	},
 	"_links": {
 		"documentation": {
-			"href": "https://docs.mollie.com/reference/v2/orders-api/cancel-order-lines",
+			"href": "https://docs.mollie.com/reference/orders-api/cancel-order-lines",
 			"type": "text/html"
 		}
 	}
@@ -1263,7 +1263,7 @@ const CreateOrderPaymentResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/orders-api/create-order-payment",
+            "href": "https://docs.mollie.com/reference/orders-api/create-order-payment",
             "type": "text/html"
         }
     }
@@ -1276,7 +1276,7 @@ const CreateOrderPaymentResponseFailed = `{
 	"detail": "Cannot create a new payment for order ord_stTC2WHAuS when the order status is \"completed\".",
 	"_links": {
 		"documentation": {
-			"href": "https://docs.mollie.com/reference/v2/orders-api/create-order-payment",
+			"href": "https://docs.mollie.com/reference/orders-api/create-order-payment",
 			"type": "text/html"
 		}
 	}
@@ -1367,7 +1367,7 @@ const CreateOrderRefundResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/orders-api/create-order-refund",
+            "href": "https://docs.mollie.com/reference/orders-api/create-order-refund",
             "type": "text/html"
         }
     }
@@ -1391,7 +1391,7 @@ const CreateOrderRefundResponseFailed = `{
 	},
 	"_links": {
 		"documentation": {
-			"href": "https://docs.mollie.com/reference/v2/orders-api/create-order-refund",
+			"href": "https://docs.mollie.com/reference/orders-api/create-order-refund",
 			"type": "text/html"
 		}
 	}
@@ -1472,7 +1472,7 @@ const ListOrderRefundResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/refunds-api/get-refund",
+                        "href": "https://docs.mollie.com/reference/refunds-api/get-refund",
                         "type": "text/html"
                     }
                 }
@@ -1490,7 +1490,7 @@ const ListOrderRefundResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/orders-api/list-order-refunds",
+            "href": "https://docs.mollie.com/reference/orders-api/list-order-refunds",
             "type": "text/html"
         }
     }
@@ -1674,7 +1674,7 @@ const ManageOrderLinesResponse = `{
          "type": "text/html"
      },
      "documentation": {
-         "href": "https://docs.mollie.com/reference/v2/orders-api/get-order",
+         "href": "https://docs.mollie.com/reference/orders-api/get-order",
          "type": "text/html"
      }
  }

--- a/testdata/organizations.go
+++ b/testdata/organizations.go
@@ -20,7 +20,7 @@ const GetOrganizationResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/organizations-api/get-organization",
+            "href": "https://docs.mollie.com/reference/organizations-api/get-organization",
             "type": "text/html"
         }
     }
@@ -74,7 +74,7 @@ const GetCurrentOrganizationResponse = `{
              "type": "application/hal+json"
          },
          "documentation": {
-             "href": "https://docs.mollie.com/reference/v2/organizations-api/current-organization",
+             "href": "https://docs.mollie.com/reference/organizations-api/current-organization",
              "type": "text/html"
          }
      }
@@ -90,7 +90,7 @@ const GetPartnerStatusResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/partners-api/get-partner",
+            "href": "https://docs.mollie.com/reference/partners-api/get-partner",
             "type": "text/html"
         },
         "signuplink": {

--- a/testdata/partners.go
+++ b/testdata/partners.go
@@ -29,7 +29,7 @@ const ListPartnerClientsResponse = `{
                   "type":"application/hal+json"
                },
                "documentation":{
-                  "href":"https://docs.mollie.com/reference/v2/partners-api/get-client",
+                  "href":"https://docs.mollie.com/reference/partners-api/get-client",
                   "type":"text/html"
                }
             }
@@ -47,7 +47,7 @@ const ListPartnerClientsResponse = `{
          "type":"application/hal+json"
       },
       "documentation":{
-         "href":"https://docs.mollie.com/reference/v2/partners-api/list-clients",
+         "href":"https://docs.mollie.com/reference/partners-api/list-clients",
          "type":"text/html"
       }
    }
@@ -78,7 +78,7 @@ const GetPartnerClientResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/partners-api/get-client",
+            "href": "https://docs.mollie.com/reference/partners-api/get-client",
             "type": "text/html"
         }
     }

--- a/testdata/payment_links.go
+++ b/testdata/payment_links.go
@@ -27,7 +27,7 @@ const GetPaymentLinkResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link",
+            "href": "https://docs.mollie.com/reference/payment-links-api/get-payment-link",
             "type": "text/html"
         }
     }
@@ -60,7 +60,7 @@ const CreatePaymentLinkResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payment-links-api/create-payment-link",
+            "href": "https://docs.mollie.com/reference/payment-links-api/create-payment-link",
             "type": "text/html"
         }
     }
@@ -96,7 +96,7 @@ const ListPaymentLinksResponse = `{
                           "type": "text/html"
                       },
                       "documentation": {
-                          "href": "https://docs.mollie.com/reference/v2/payment-links-api/get-payment-link",
+                          "href": "https://docs.mollie.com/reference/payment-links-api/get-payment-link",
                           "type": "text/html"
                       }
                   }
@@ -114,7 +114,7 @@ const ListPaymentLinksResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payment-links-api/list-payment-links",
+            "href": "https://docs.mollie.com/reference/payment-links-api/list-payment-links",
             "type": "text/html"
         }
     }

--- a/testdata/payments.go
+++ b/testdata/payments.go
@@ -39,7 +39,7 @@ const GetPaymentResponse = `{
             "type": "application/json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payments-api/get-payment",
+            "href": "https://docs.mollie.com/reference/payments-api/get-payment",
             "type": "text/html"
         }
     }
@@ -75,7 +75,7 @@ const CancelPaymentResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payments-api/cancel-payment",
+            "href": "https://docs.mollie.com/reference/payments-api/cancel-payment",
             "type": "text/html"
         }
     }
@@ -114,7 +114,7 @@ const UpdatePaymentResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payments-api/update-payment",
+            "href": "https://docs.mollie.com/reference/payments-api/update-payment",
             "type": "text/html"
         }
     }
@@ -168,7 +168,7 @@ const ListPaymentsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/payments-api/list-payments",
+            "href": "https://docs.mollie.com/reference/payments-api/list-payments",
             "type": "text/html"
         }
     }

--- a/testdata/permissions.go
+++ b/testdata/permissions.go
@@ -12,7 +12,7 @@ const GetPermissionsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/permissions-api/get-permission",
+            "href": "https://docs.mollie.com/reference/permissions-api/get-permission",
             "type": "text/html"
         }
     }
@@ -52,7 +52,7 @@ const ListPermissionsResponse = `{
     "count": 15,
     "_links": {
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/permissions-api/list-permissions",
+            "href": "https://docs.mollie.com/reference/permissions-api/list-permissions",
             "type": "text/html"
         },
         "self": {

--- a/testdata/profiles.go
+++ b/testdata/profiles.go
@@ -45,7 +45,7 @@ const GetProfileResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/create-profile",
+            "href": "https://docs.mollie.com/reference/profiles-api/create-profile",
             "type": "text/html"
         }
     }
@@ -95,7 +95,7 @@ const GetProfilesListResponse = `{
                         "type": "text/html"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/profiles-api/create-profile",
+                        "href": "https://docs.mollie.com/reference/profiles-api/create-profile",
                         "type": "text/html"
                     }
                 }
@@ -105,7 +105,7 @@ const GetProfilesListResponse = `{
     "count": 5,
     "_links": {
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/list-profiles",
+            "href": "https://docs.mollie.com/reference/profiles-api/list-profiles",
             "type": "text/html"
         },
         "self": {
@@ -159,7 +159,7 @@ const CreateProfileResponse = `
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/create-profile",
+            "href": "https://docs.mollie.com/reference/profiles-api/create-profile",
             "type": "text/html"
         }
     }
@@ -205,7 +205,7 @@ const UpdateProfileResponse = `{
             "type": "text/html"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/create-profile",
+            "href": "https://docs.mollie.com/reference/profiles-api/create-profile",
             "type": "text/html"
         }
     }
@@ -227,7 +227,7 @@ const EnablePaymentMethodResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/activate-method",
+            "href": "https://docs.mollie.com/reference/profiles-api/activate-method",
             "type": "text/html"
         }
     }
@@ -246,7 +246,7 @@ const EnableGiftCardIssuerResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/profiles-api/enable-giftcard-issuer",
+            "href": "https://docs.mollie.com/reference/profiles-api/enable-giftcard-issuer",
             "type": "text/html"
         }
     }
@@ -275,7 +275,7 @@ const EnableVoucherIssuerResponse = `{
              "type": "application/hal+json"
          },
          "documentation": {
-             "href": "https://docs.mollie.com/reference/v2/profiles-api/enable-voucher-issuer",
+             "href": "https://docs.mollie.com/reference/profiles-api/enable-voucher-issuer",
              "type": "text/html"
          }
      }

--- a/testdata/refunds.go
+++ b/testdata/refunds.go
@@ -25,7 +25,7 @@ const CreatePaymentRefundResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/refunds-api/create-payment-refund",
+            "href": "https://docs.mollie.com/reference/refunds-api/create-payment-refund",
             "type": "text/html"
         }
     }
@@ -56,7 +56,7 @@ const GetPaymentRefundResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund",
+            "href": "https://docs.mollie.com/reference/refunds-api/get-payment-refund",
             "type": "text/html"
         }
     }
@@ -91,7 +91,7 @@ const ListPaymentRefundsResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund",
+                        "href": "https://docs.mollie.com/reference/refunds-api/get-payment-refund",
                         "type": "text/html"
                     }
                 }
@@ -109,7 +109,7 @@ const ListPaymentRefundsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/refunds-api/list-payment-refunds",
+            "href": "https://docs.mollie.com/reference/refunds-api/list-payment-refunds",
             "type": "text/html"
         }
     }
@@ -191,7 +191,7 @@ const ListOrderRefundsResponse = `
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/refunds-api/get-order-refund",
+                        "href": "https://docs.mollie.com/reference/refunds-api/get-order-refund",
                         "type": "text/html"
                     }
                 }
@@ -209,7 +209,7 @@ const ListOrderRefundsResponse = `
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/refunds-api/list-order-refunds",
+            "href": "https://docs.mollie.com/reference/refunds-api/list-order-refunds",
             "type": "text/html"
         }
     }
@@ -244,7 +244,7 @@ const ListRefundsResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/refunds-api/get-payment-refund",
+                        "href": "https://docs.mollie.com/reference/refunds-api/get-payment-refund",
                         "type": "text/html"
                     }
                 }
@@ -262,7 +262,7 @@ const ListRefundsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/refunds-api/list-refunds",
+            "href": "https://docs.mollie.com/reference/refunds-api/list-refunds",
             "type": "text/html"
         }
     }

--- a/testdata/settlements.go
+++ b/testdata/settlements.go
@@ -125,7 +125,7 @@ const GetSettlementsResponse = `{
              "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/settlements-api/get-settlement",
+            "href": "https://docs.mollie.com/reference/settlements-api/get-settlement",
             "type": "text/html"
         }
     }
@@ -235,7 +235,7 @@ const GetNextSettlementResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement",
+            "href": "https://docs.mollie.com/reference/settlements-api/get-next-settlement",
             "type": "text/html"
         }
     }
@@ -345,7 +345,7 @@ const GetOpenSettlementResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/settlements-api/get-next-settlement",
+            "href": "https://docs.mollie.com/reference/settlements-api/get-next-settlement",
             "type": "text/html"
         }
     }
@@ -397,7 +397,7 @@ const ListSettlementsResponse = `
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/settlements-api/get-settlement",
+                        "href": "https://docs.mollie.com/reference/settlements-api/get-settlement",
                         "type": "text/html"
                     }
                 }
@@ -415,7 +415,7 @@ const ListSettlementsResponse = `
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/settlements-api/list-settlements",
+            "href": "https://docs.mollie.com/reference/settlements-api/list-settlements",
             "type": "text/html"
         }
     }

--- a/testdata/shipments.go
+++ b/testdata/shipments.go
@@ -99,7 +99,7 @@ const GetShipmentsResponse = `{
              "type": "application/hal+json"
          },
          "documentation": {
-             "href": "https://docs.mollie.com/reference/v2/shipments-api/get-shipment",
+             "href": "https://docs.mollie.com/reference/shipments-api/get-shipment",
              "type": "text/html"
          }
      }
@@ -173,7 +173,7 @@ const ListShipmentsResponse = `{
                         "type": "application/hal+json"
                     },
                     "documentation": {
-                        "href": "https://docs.mollie.com/reference/v2/shipments-api/get-shipment",
+                        "href": "https://docs.mollie.com/reference/shipments-api/get-shipment",
                         "type": "text/html"
                     }
                 }
@@ -187,7 +187,7 @@ const ListShipmentsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/shipments-api/list-shipments",
+            "href": "https://docs.mollie.com/reference/shipments-api/list-shipments",
             "type": "text/html"
         }
     }

--- a/testdata/subscriptions.go
+++ b/testdata/subscriptions.go
@@ -41,7 +41,7 @@ const GetSubscriptionResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/subscriptions-api/get-subscription",
+            "href": "https://docs.mollie.com/reference/subscriptions-api/get-subscription",
             "type": "text/html"
         }
     }
@@ -76,7 +76,7 @@ const DeleteSubscriptionResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/subscriptions-api/cancel-subscription",
+            "href": "https://docs.mollie.com/reference/subscriptions-api/cancel-subscription",
             "type": "text/html"
         }
     }
@@ -133,7 +133,7 @@ const ListAllSubscriptionsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/subscriptions-api/list-all-subscriptions",
+            "href": "https://docs.mollie.com/reference/subscriptions-api/list-all-subscriptions",
             "type": "text/html"
         }
     }

--- a/testdata/terminals.go
+++ b/testdata/terminals.go
@@ -108,7 +108,7 @@ const ListTerminalsResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/terminals-api/list-terminals",
+            "href": "https://docs.mollie.com/reference/terminals-api/list-terminals",
             "type": "text/html"
         }
     }
@@ -132,7 +132,7 @@ const GetTerminalResponse = `{
             "type": "application/hal+json"
         },
         "documentation": {
-            "href": "https://docs.mollie.com/reference/v2/terminals-api/get-terminal",
+            "href": "https://docs.mollie.com/reference/terminals-api/get-terminal",
             "type": "text/html"
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

This PR fixes all the documentation links to Mollie's API Reference. It also automates the checking process using a github action.

## Motivation and context

Closes #381 

## How has this been tested?

Broken links are checked using [lychee](https://github.com/lycheeverse/lychee).

If you are running the tests locally, please specify:

- OS: macos Sonoma
- Go version 1.23.1

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

