### PR TITLE
chore(actions): skip link checking if pr is opened by dependabot

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   linkChecker:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Avoids running the link-checker action when the PR is opened by dependabot.

## Motivation and context

Existing PRs failing because the link-checker fails.

