### PR TITLE
Fix Amount struct for correct url query encoding.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -110,7 +110,15 @@
         "editor.fontFamily": "'Fira Code', Menlo, Monaco, 'Courier New', monospace",
         "editor.fontLigatures": true,
         "files.insertFinalNewline": true,
-        "files.trimFinalNewlines": true
+        "files.trimFinalNewlines": true,
+        "cSpell.ignorePaths": [
+          ".devcontainer/*",
+          "mollie/*_test.go",
+          "testdata/*",
+          ".git/objects",
+          ".vscode",
+          ".github"
+        ]
       }
     }
   },

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -25,7 +25,7 @@ jobs:
         uses: lycheeverse/lychee-action@7da8ec1fc4e01b5a12062ac6c589c10a4ce70d67
 
       - name: Create Issue From File
-        if: env.lychee_exit_code != 0
+        if: ${{ env.lychee_exit_code != 0 }}
         uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd
         with:
           title: Link Checker Report
@@ -33,5 +33,4 @@ jobs:
           labels: |
             report
             automated-issue
-            help-wanted
           assignees: VictorAvelar

--- a/mollie/common_types.go
+++ b/mollie/common_types.go
@@ -9,8 +9,8 @@ import (
 
 // Amount represents a currency and value pair.
 type Amount struct {
-	Currency string `json:"currency,omitempty" url:"currency,omitempty"`
-	Value    string `json:"value,omitempty"    url:"value,omitempty"`
+	Currency string `json:"currency,omitempty" url:"amount[currency],omitempty"`
+	Value    string `json:"value,omitempty"    url:"amount[value],omitempty"`
 }
 
 // Address provides a human friendly representation of a geographical space.

--- a/mollie/common_types_test.go
+++ b/mollie/common_types_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-querystring/query"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +49,25 @@ func TestShortDate_MarshalJSON(t *testing.T) {
 		_, err := d.MarshalJSON()
 		assert.Nil(t, err)
 	})
+}
+
+func TestURLQueryEncode(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       any
+		expected string
+	}{
+		{
+			"test amount encode",
+			&Amount{Currency: "EUR", Value: "10.00"},
+			"amount%5Bcurrency%5D=EUR&amount%5Bvalue%5D=10.00",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v, _ := query.Values(c.in)
+			assert.Equal(t, c.expected, v.Encode())
+		})
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Fixes the way in which an `Amount` object is encoded as url query params, the existing code was encoding value and currency as separate url params which was not correct for Mollie.

## Motivation and context

Library bug fix.

## How has this been tested?

- [x] Unit tests added / updated
- [x] The tests run on docker (using `task test`)
- [ ] The required `test data` has been added / updated

If you are running the tests locally, please specify:

- OS: macos Sonoma
- Go version 1.23.x

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] This change requires a documentation update

## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
