### PR TITLE
chore(go): upgrade go directive to at least 1.23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        go: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        go: [1.23.x, 1.23.x]
     name: Go ${{ matrix.go }} check
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        go: [1.23.x, 1.23.x]
+        go: [1.23.x, 1.24.x]
     name: Go ${{ matrix.go }} check
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ For leveraging [Mollie Connect](https://docs.mollie.com/oauth/overview) (advance
 go get -u github.com/VictorAvelar/mollie-api-go/v4/mollie
 ```
 
+## Notice
+
+> Version 4.6.0 raises the minimum go version to v1.23, patches will likely be backported to v4.5.x but new features will only be available in versions > v4.6.0.
+
+The above notice aligns with the go [EOL](https://endoflife.date/go) policy schedule.
+
 ## Usage
 
 ### Testing using API tokens

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictorAvelar/mollie-api-go/v4
 
-go 1.20
+go 1.23
 
 require (
 	github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
This pull request updates the Go version requirements and provides a notice about these changes in the documentation. The most important changes include updating the Go version in the workflow configuration and `go.mod` file, and adding a notice in the `README.md` file about the new minimum Go version.

Updates to Go version:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L36-R36): Updated the Go version matrix to only include version 1.23.x.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the required Go version to 1.23.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R34-R39): Added a notice about the new minimum Go version being 1.23 and the backporting policy for patches.