### PR TITLE
chore(readme): add deepwiki documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Mollie API Golang client
 
+## Deepwiki
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/VictorAvelar/mollie-api-go)
+
 ## Actions
 
 [![testing](https://github.com/VictorAvelar/mollie-api-go/actions/workflows/tests.yml/badge.svg)](https://github.com/VictorAvelar/mollie-api-go/actions/workflows/tests.yml)


### PR DESCRIPTION
This pull request introduces a small update to the `README.md` file by adding a badge for Deepwiki, which links to the project's page on Deepwiki.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R6): Added a Deepwiki badge and link to the project's Deepwiki page to enhance visibility and documentation accessibility.
