### PR TITLE
Payment details should be optional, changing PaymentDetails to pointer in CreateSalesInvoice

### DIFF
--- a/mollie/sales_invoices.go
+++ b/mollie/sales_invoices.go
@@ -136,22 +136,22 @@ type SalesInvoiceLinks struct {
 
 // CreateSalesInvoice represents the payload to create a sales invoice.
 type CreateSalesInvoice struct {
-	TestMode            bool                       `json:"testmode,omitempty"`
-	ProfileID           string                     `json:"profileId,omitempty"`
-	CustomerID          string                     `json:"customerId,omitempty"`
-	MandateID           string                     `json:"mandateId,omitempty"`
-	RecipientIdentifier string                     `json:"recipientIdentifier,omitempty"`
-	Memo                string                     `json:"memo,omitempty"`
-	Metadata            map[string]string          `json:"metadata,omitempty"`
-	Status              SalesInvoiceStatus         `json:"status,omitempty"`
-	VATScheme           SalesInvoiceVATScheme      `json:"vatScheme,omitempty"`
-	VATMode             SalesInvoiceVATMode        `json:"vatMode,omitempty"`
-	PaymentTerm         SalesInvoicePaymentTerm    `json:"paymentTerm,omitempty"`
-	PaymentDetails      SalesInvoicePaymentDetails `json:"paymentDetails,omitempty"`
-	EmailDetails        SalesInvoiceEmailDetails   `json:"emailDetails,omitempty"`
-	Recipient           SalesInvoiceRecipient      `json:"recipient,omitempty"`
-	Lines               []SalesInvoiceLineItem     `json:"lines,omitempty"`
-	Discount            *SalesInvoiceDiscount      `json:"discount,omitempty"`
+	TestMode            bool                        `json:"testmode,omitempty"`
+	ProfileID           string                      `json:"profileId,omitempty"`
+	CustomerID          string                      `json:"customerId,omitempty"`
+	MandateID           string                      `json:"mandateId,omitempty"`
+	RecipientIdentifier string                      `json:"recipientIdentifier,omitempty"`
+	Memo                string                      `json:"memo,omitempty"`
+	Metadata            map[string]string           `json:"metadata,omitempty"`
+	Status              SalesInvoiceStatus          `json:"status,omitempty"`
+	VATScheme           SalesInvoiceVATScheme       `json:"vatScheme,omitempty"`
+	VATMode             SalesInvoiceVATMode         `json:"vatMode,omitempty"`
+	PaymentTerm         SalesInvoicePaymentTerm     `json:"paymentTerm,omitempty"`
+	PaymentDetails      *SalesInvoicePaymentDetails `json:"paymentDetails,omitempty"`
+	EmailDetails        SalesInvoiceEmailDetails    `json:"emailDetails,omitempty"`
+	Recipient           SalesInvoiceRecipient       `json:"recipient,omitempty"`
+	Lines               []SalesInvoiceLineItem      `json:"lines,omitempty"`
+	Discount            *SalesInvoiceDiscount       `json:"discount,omitempty"`
 }
 
 // UpdateSalesInvoice represents the payload to update a sales invoice.


### PR DESCRIPTION
# Description

The PaymentDetails in CreateSalesInvoice are optional. When creating a sales invoice with the "Issued" status, it is not possible to provide any PaymentDetails. The Mollie API fails when the empty object is added in the request body. 

I have changed the PaymentDetails to a pointer, such that the field is omitted when not filled out.

## Motivation and context

fixes #501 

## How has this been tested?

I've added a unit tests, but given that this is a response from the Mollie Server, I've added the expected errors from Mollie to the handler and check the code responds correctly. I've tested this against the real Mollie server in our own usage of the client, in which this works.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our continuous integration server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
