### PR TITLE
Adds commission and Embedded structure for LinkedClient

### DIFF
--- a/mollie/capabilities.go
+++ b/mollie/capabilities.go
@@ -1,0 +1,55 @@
+package mollie
+
+import "time"
+
+// Capabilities describes what capabilities the organization can perform.
+type Capabilities struct {
+	Resource     string                    `json:"resource,omitempty"`
+	Name         string                    `json:"name,omitempty"`
+	Status       CapabilitiesStatus        `json:"status,omitempty"`
+	StatusReason *CapabilitiesStatusReason `json:"statusReason,omitempty"`
+	Requirements []CapabilityRequirement   `json:"requirements,omitempty"`
+}
+
+// CapabilitiesStatus describes status of capability.
+type CapabilitiesStatus string
+
+// Valid capability status.
+const (
+	CapabilityUnrequested CapabilitiesStatus = "unrequested"
+	CapabilityEnabled     CapabilitiesStatus = "enabled"
+	CapabilityDisabled    CapabilitiesStatus = "disabled"
+	CapabilityPending     CapabilitiesStatus = "pending"
+)
+
+// CapabilitiesStatusReason describes reason for status of capability.
+type CapabilitiesStatusReason string
+
+// Valid capability status reasons.
+const (
+	CapabilitiesStatusReasonRequirementPastDue        CapabilitiesStatusReason = "requirement-past-due"
+	CapabilityStatusReasonOnboardingInformationNeeded CapabilitiesStatusReason = "onboarding-information-needed"
+)
+
+// CapabilityRequirement referring to the task to be fulfilled by the organization to enable or re-enable the capability
+type CapabilityRequirement struct {
+	Id      string                      `json:"id"`
+	Status  CapabilityRequirementStatus `json:"status"`
+	DueDate *time.Time                  `json:"dueDate,omitempty"`
+	Links   CapabilityRequirementLinks  `json:"_links,omitempty"`
+}
+
+// CapabilityRequirementStatus describes status of capability requirement.
+type CapabilityRequirementStatus string
+
+// Valid capability requirement status.
+const (
+	CapabilityRequirementCurrentlyDue CapabilityRequirementStatus = "currently-due"
+	CapabilityRequirementPastDue      CapabilityRequirementStatus = "past-due"
+	CapabilityRequirementRequested    CapabilityRequirementStatus = "requested"
+)
+
+// CapabilityRequirementLinks contains URL objects relevant to the requirements.
+type CapabilityRequirementLinks struct {
+	Dashboard *URL `json:"dashboard,omitempty"`
+}

--- a/mollie/clients.go
+++ b/mollie/clients.go
@@ -9,10 +9,12 @@ import (
 
 // LinkedClient describes a single client, linked to your partner account.
 type LinkedClient struct {
-	Resource              string            `json:"resource,omitempty"`
-	ID                    string            `json:"id,omitempty"`
-	OrganizationCreatedAt *time.Time        `json:"organizationCreatedAt,omitempty"`
-	Links                 LinkedClientLinks `json:"_links,omitempty"`
+	Resource              string                 `json:"resource,omitempty"`
+	ID                    string                 `json:"id,omitempty"`
+	Commission            LinkedClientCommission `json:"commission,omitempty"`
+	OrganizationCreatedAt *time.Time             `json:"organizationCreatedAt,omitempty"`
+	Links                 LinkedClientLinks      `json:"_links,omitempty"`
+	Embedded              *LinkedClientEmbedded  `json:"_embedded,omitempty"`
 }
 
 // LinkedClientLinks contains URL objects relevant to the client.
@@ -25,7 +27,7 @@ type LinkedClientLinks struct {
 
 // GetLinkedClientOptions contains valid query parameters for the get clients endpoint.
 type GetLinkedClientOptions struct {
-	Embed []EmbedValue `url:"embed,omitempty"`
+	Embed []EmbedValue `url:"embed,omitempty,comma"`
 }
 
 // LinkedClientList describes a list of partner clients.
@@ -37,11 +39,23 @@ type LinkedClientList struct {
 	Links PaginationLinks `json:"_links,omitempty"`
 }
 
+// LinkedClientCommission contains the commission object
+type LinkedClientCommission struct {
+	Count int `json:"count"`
+}
+
+// LinkedClientEmbedded contains embedded objects for the client.
+type LinkedClientEmbedded struct {
+	Organization *Organization `json:"organization,omitempty"`
+	Onboarding   *Onboarding   `json:"onboarding,omitempty"`
+	Capabilities *Capabilities `json:"capabilities,omitempty"`
+}
+
 // ListLinkedClientsOptions contains valid query parameters for the list clients endpoint.
 type ListLinkedClientsOptions struct {
 	Limit int          `url:"limit,omitempty"`
 	From  string       `url:"from,omitempty"`
-	Embed []EmbedValue `url:"embed,omitempty"`
+	Embed []EmbedValue `url:"embed,omitempty,comma"`
 }
 
 // ClientsService operates over the partners API.

--- a/mollie/common_types.go
+++ b/mollie/common_types.go
@@ -344,6 +344,7 @@ const (
 	EmbedCaptures     EmbedValue = "captures"
 	EmbedOrganization EmbedValue = "organization"
 	EmbedOnboarding   EmbedValue = "onboarding"
+	EmbedCapabilities EmbedValue = "capabilities"
 )
 
 // Rate describes service rates, further divided into fixed and percentage costs.


### PR DESCRIPTION
The client Get and List endpoints were missing the ability to get the embedded objects, also the embed option wrongly encodes the query params.

# Description

- Adds commission and embedded data to the linked client
- Adds capabilites object for the embedded data on the linked client
- Bugfixes when having multiple embed params only the last one was picked. Needed to be comma separated query param.