### PR TITLE
Sync UpdateSalesInvoice with API docs

### DIFF
--- a/mollie/sales_invoices.go
+++ b/mollie/sales_invoices.go
@@ -165,8 +165,8 @@ type UpdateSalesInvoice struct {
 	Status              SalesInvoiceStatus          `json:"status,omitempty"`
 	PaymentTerm         SalesInvoicePaymentTerm     `json:"paymentTerm,omitempty"`
 	PaymentDetails      *SalesInvoicePaymentDetails `json:"paymentDetails,omitempty"`
-	EmailDetails        SalesInvoiceEmailDetails    `json:"emailDetails,omitempty"`
-	Recipient           SalesInvoiceRecipient       `json:"recipient,omitempty"`
+	EmailDetails        *SalesInvoiceEmailDetails    `json:"emailDetails,omitempty"`
+	Recipient           *SalesInvoiceRecipient       `json:"recipient,omitempty"`
 	Lines               []SalesInvoiceLineItem      `json:"lines,omitempty"`
 	Discount            *SalesInvoiceDiscount       `json:"discount,omitempty"`
 }

--- a/mollie/sales_invoices.go
+++ b/mollie/sales_invoices.go
@@ -26,7 +26,7 @@ type SalesInvoiceSource string
 // Possible values for SalesInvoiceSource.
 const (
 	ManualSalesInvoiceSource      SalesInvoiceSource = "manual"
-	PaymentLinkSalesInvoiceSource SalesInvoiceSource = "payment_link"
+	PaymentLinkSalesInvoiceSource SalesInvoiceSource = "payment-link"
 	PaymentSalesInvoiceSource     SalesInvoiceSource = "payment"
 )
 
@@ -63,7 +63,8 @@ const (
 	PaymentTerm30Days SalesInvoicePaymentTerm = "30 days"
 	PaymentTerm45Days SalesInvoicePaymentTerm = "45 days"
 	PaymentTerm60Days SalesInvoicePaymentTerm = "60 days"
-	PaymentTerm90Days SalesInvoicePaymentTerm = "90 days"
+	PaymentTerm90Days  SalesInvoicePaymentTerm = "90 days"
+	PaymentTerm120Days SalesInvoicePaymentTerm = "120 days"
 )
 
 // SalesInvoiceRecipientType represents the type of recipient for the sales invoice.
@@ -157,16 +158,17 @@ type CreateSalesInvoice struct {
 
 // UpdateSalesInvoice represents the payload to update a sales invoice.
 type UpdateSalesInvoice struct {
-	TestMode            bool                     `json:"testmode,omitempty"`
-	IsEInvoice          bool                     `json:"isEInvoice,omitempty"`
-	Memo                string                   `json:"memo,omitempty"`
-	RecipientIdentifier string                   `json:"recipientIdentifier,omitempty"`
-	Status              SalesInvoiceStatus       `json:"status,omitempty"`
-	PaymentTerm         SalesInvoicePaymentTerm  `json:"paymentTerm,omitempty"`
-	EmailDetails        SalesInvoiceEmailDetails `json:"emailDetails,omitempty"`
-	Recipient           SalesInvoiceRecipient    `json:"recipient,omitempty"`
-	Lines               []SalesInvoiceLineItem   `json:"lines,omitempty"`
-	Discount            *SalesInvoiceDiscount    `json:"discount,omitempty"`
+	TestMode            bool                        `json:"testmode,omitempty"`
+	IsEInvoice          bool                        `json:"isEInvoice,omitempty"`
+	Memo                string                      `json:"memo,omitempty"`
+	RecipientIdentifier string                      `json:"recipientIdentifier,omitempty"`
+	Status              SalesInvoiceStatus          `json:"status,omitempty"`
+	PaymentTerm         SalesInvoicePaymentTerm     `json:"paymentTerm,omitempty"`
+	PaymentDetails      *SalesInvoicePaymentDetails `json:"paymentDetails,omitempty"`
+	EmailDetails        SalesInvoiceEmailDetails    `json:"emailDetails,omitempty"`
+	Recipient           SalesInvoiceRecipient       `json:"recipient,omitempty"`
+	Lines               []SalesInvoiceLineItem      `json:"lines,omitempty"`
+	Discount            *SalesInvoiceDiscount       `json:"discount,omitempty"`
 }
 
 // SalesInvoice represents a sales invoice resource.

--- a/mollie/sales_invoices_test.go
+++ b/mollie/sales_invoices_test.go
@@ -738,6 +738,46 @@ func TestSalesInvoicesService_Update(t *testing.T) {
 			},
 		},
 		{
+			name: "update sales invoice with payment details",
+			args: args{
+				ctx: context.Background(),
+				id:  "invoice_4Y0eZitmBnQ6IDoMqZQKh",
+				req: UpdateSalesInvoice{
+					Status: PaidSalesInvoiceStatus,
+					PaymentDetails: &SalesInvoicePaymentDetails{
+						Source:          ManualSalesInvoiceSource,
+						SourceReference: "ref_123",
+					},
+				},
+			},
+			wantErr: false,
+			pre:     noPre,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "PATCH")
+
+				if _, ok := r.Header[AuthHeader]; !ok {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				pd, ok := payload["paymentDetails"].(map[string]any)
+				assert.True(t, ok)
+				assert.Equal(t, "manual", pd["source"])
+				assert.Equal(t, "ref_123", pd["sourceReference"])
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(testdata.GetSalesInvoicesResponse))
+			},
+		},
+		{
 			"update sales invoice works as expected with access tokens",
 			args{
 				context.Background(),


### PR DESCRIPTION
# Description

Sync the `UpdateSalesInvoice` struct and related types with the current [Mollie API documentation](https://docs.mollie.com/reference/update-sales-invoice).

## Motivation and context

The `UpdateSalesInvoice` struct was missing the `PaymentDetails` field (required when setting status to `paid`), the `PaymentTerm120Days` constant was absent, and the `PaymentLinkSalesInvoiceSource` value used an underscore instead of a hyphen.

## How has this been tested?

- [x] Unit tests added / updated
- [x] Full test suite passes with `go test -v -race ./...`

- OS: macOS
- Go version: current

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.