### PR TITLE
Allow EmailDetails to be nil on CreateSalesInvoice

### DIFF
--- a/mollie/sales_invoices.go
+++ b/mollie/sales_invoices.go
@@ -149,7 +149,7 @@ type CreateSalesInvoice struct {
 	VATMode             SalesInvoiceVATMode         `json:"vatMode,omitempty"`
 	PaymentTerm         SalesInvoicePaymentTerm     `json:"paymentTerm,omitempty"`
 	PaymentDetails      *SalesInvoicePaymentDetails `json:"paymentDetails,omitempty"`
-	EmailDetails        SalesInvoiceEmailDetails    `json:"emailDetails,omitempty"`
+	EmailDetails        *SalesInvoiceEmailDetails   `json:"emailDetails,omitempty"`
 	Recipient           SalesInvoiceRecipient       `json:"recipient,omitempty"`
 	Lines               []SalesInvoiceLineItem      `json:"lines,omitempty"`
 	Discount            *SalesInvoiceDiscount       `json:"discount,omitempty"`

--- a/mollie/sales_invoices_test.go
+++ b/mollie/sales_invoices_test.go
@@ -271,6 +271,84 @@ func TestSalesInvoicesService_Create(t *testing.T) {
 			},
 		},
 		{
+			name: "create sales invoice with email details",
+			args: args{
+				ctx: context.Background(),
+				req: CreateSalesInvoice{
+					Status:              DraftSalesInvoiceStatus,
+					RecipientIdentifier: "customer_123456789",
+					Recipient:           recipient,
+					Lines:               lines,
+					EmailDetails: &SalesInvoiceEmailDetails{
+						Subject: "Your invoice",
+						Body:    "Please find your invoice attached.",
+					},
+				},
+			},
+			wantErr: false,
+			pre:     noPre,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
+
+				if _, ok := r.Header[AuthHeader]; !ok {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				emailDetails, ok := payload["emailDetails"].(map[string]any)
+				assert.True(t, ok)
+				assert.Equal(t, "Your invoice", emailDetails["subject"])
+				assert.Equal(t, "Please find your invoice attached.", emailDetails["body"])
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(testdata.CreateSalesInvoicesResponse))
+			},
+		},
+		{
+			name: "create sales invoice without email details omits field",
+			args: args{
+				ctx: context.Background(),
+				req: CreateSalesInvoice{
+					Status:              DraftSalesInvoiceStatus,
+					RecipientIdentifier: "customer_123456789",
+					Recipient:           recipient,
+					Lines:               lines,
+				},
+			},
+			wantErr: false,
+			pre:     noPre,
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				testHeader(t, r, AuthHeader, "Bearer token_X12b31ggg23")
+				testMethod(t, r, "POST")
+
+				if _, ok := r.Header[AuthHeader]; !ok {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				_, hasEmailDetails := payload["emailDetails"]
+				assert.False(t, hasEmailDetails, "emailDetails should be omitted when nil")
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(testdata.CreateSalesInvoicesResponse))
+			},
+		},
+		{
 			name: "create issued sales invoice, without payment details",
 			args: args{
 				ctx: context.Background(),


### PR DESCRIPTION
# Description

Make `EmailDetails` in `CreateSalesInvoice` a pointer field (`*SalesInvoiceEmailDetails`) so it is omitted from the JSON payload when not set, matching the existing pattern used by `PaymentDetails` and `Discount`.

## Motivation and context

When `EmailDetails` was a value type, `json:"omitempty"` would still serialize the zero-value struct as `"emailDetails": {}` in the request payload. Making it a pointer ensures it is truly omitted when nil, which is the correct behavior for an optional field in the Mollie API.

## How has this been tested?

Two new test cases were added to `TestSalesInvoicesService_Create`:

- **"create sales invoice with email details"** — verifies that when `EmailDetails` is provided (non-nil pointer), the `emailDetails` field is present in the JSON payload with the correct `subject` and `body`.
- **"create sales invoice without email details omits field"** — verifies that when `EmailDetails` is nil, the `emailDetails` key is absent from the JSON payload.

- [x] Unit tests added / updated
- [ ] The tests run on docker (using `make test`)
- [ ] The required `test data` has been added / updated

- OS: macOS
- Go version: see go.mod

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.